### PR TITLE
fix: Fix critical deadlock and hanging issues in async processors

### DIFF
--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultRateLimitedParallelAsyncProcessor_2.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultRateLimitedParallelAsyncProcessor_2.cs
@@ -15,10 +15,11 @@ public class ResultRateLimitedParallelAsyncProcessor<TInput, TOutput> : ResultAb
     internal override Task Process()
     {
         // For rate-limited processing, we want strict parallelism control
+        // TaskWrapper.Process already includes Task.Yield to prevent thread pool blocking
         return TaskWrappers.InParallelAsync(_levelsOfParallelism, 
             async taskWrapper =>
             {
-                await Task.Run(() => taskWrapper.Process(CancellationToken)).ConfigureAwait(false);
+                await taskWrapper.Process(CancellationToken).ConfigureAwait(false);
             }, CancellationToken.None);
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultTimedRateLimitedParallelAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultTimedRateLimitedParallelAsyncProcessor_1.cs
@@ -17,11 +17,12 @@ public class ResultTimedRateLimitedParallelAsyncProcessor<TOutput> : ResultAbstr
     internal override Task Process()
     {
         // For timed rate-limited processing, we want strict parallelism control
+        // TaskWrapper.Process already includes Task.Yield to prevent thread pool blocking
         return TaskWrappers.InParallelAsync(_levelsOfParallelism, 
             async taskWrapper =>
             {
                 await Task.WhenAll(
-                    Task.Run(() => taskWrapper.Process(CancellationToken)),
+                    taskWrapper.Process(CancellationToken),
                     Task.Delay(_timeSpan, CancellationToken)).ConfigureAwait(false);
             }, CancellationToken.None);
     }

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultTimedRateLimitedParallelAsyncProcessor_2.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultTimedRateLimitedParallelAsyncProcessor_2.cs
@@ -17,11 +17,12 @@ public class ResultTimedRateLimitedParallelAsyncProcessor<TInput, TOutput> : Res
     internal override Task Process()
     {
         // For timed rate-limited processing, we want strict parallelism control
+        // TaskWrapper.Process already includes Task.Yield to prevent thread pool blocking
         return TaskWrappers.InParallelAsync(_levelsOfParallelism, 
             async taskWrapper =>
             {
                 await Task.WhenAll(
-                    Task.Run(() => taskWrapper.Process(CancellationToken)),
+                    taskWrapper.Process(CancellationToken),
                     Task.Delay(_timeSpan, CancellationToken)).ConfigureAwait(false);
             }, CancellationToken.None);
     }

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultUnboundedParallelAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultUnboundedParallelAsyncProcessor_1.cs
@@ -4,8 +4,24 @@ namespace EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors;
 
 /// <summary>
 /// A specialized parallel processor that starts ALL tasks immediately without any concurrency limits and returns results.
-/// WARNING: Use with caution - this can overwhelm system resources with large task counts.
-/// Ideal for scenarios where you need maximum parallelism and have sufficient resources.
+/// WARNING: Use with extreme caution - this WILL overwhelm system resources with large task counts.
+/// 
+/// RISKS:
+/// - No concurrency throttling - all tasks start immediately
+/// - Can cause thread pool starvation with thousands of tasks
+/// - May exhaust system memory with very large collections
+/// - Can lead to degraded system performance
+/// 
+/// RECOMMENDATIONS:
+/// - For collections > 1000 items, use ResultParallelAsyncProcessor with appropriate concurrency limits
+/// - Monitor system resources when using this processor
+/// - Consider the bounded alternatives for production use
+/// 
+/// Ideal only for scenarios with:
+/// - Small task counts (< 100)
+/// - Very lightweight operations
+/// - Sufficient system resources
+/// - Controlled environments where task count is known
 /// </summary>
 public class ResultUnboundedParallelAsyncProcessor<TOutput> : ResultAbstractAsyncProcessor<TOutput>
 {
@@ -17,15 +33,7 @@ public class ResultUnboundedParallelAsyncProcessor<TOutput> : ResultAbstractAsyn
     {
         // Start ALL tasks immediately without any throttling
         // This provides true unbounded parallelism
-        var tasks = TaskWrappers.Select(taskWrapper => 
-        {
-            var task = taskWrapper.Process(CancellationToken);
-            // Fast-path for already completed tasks
-            if (task.IsCompleted)
-            {
-            }
-            return task;
-        });
+        var tasks = TaskWrappers.Select(taskWrapper => taskWrapper.Process(CancellationToken));
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
     }

--- a/EnumerableAsyncProcessor/RunnableProcessors/UnboundedParallelAsyncProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/UnboundedParallelAsyncProcessor.cs
@@ -4,8 +4,24 @@ namespace EnumerableAsyncProcessor.RunnableProcessors;
 
 /// <summary>
 /// A specialized parallel processor that starts ALL tasks immediately without any concurrency limits.
-/// WARNING: Use with caution - this can overwhelm system resources with large task counts.
-/// Ideal for scenarios where you need maximum parallelism and have sufficient resources.
+/// WARNING: Use with extreme caution - this WILL overwhelm system resources with large task counts.
+/// 
+/// RISKS:
+/// - No concurrency throttling - all tasks start immediately
+/// - Can cause thread pool starvation with thousands of tasks
+/// - May exhaust system memory with very large collections
+/// - Can lead to degraded system performance
+/// 
+/// RECOMMENDATIONS:
+/// - For collections > 1000 items, use ParallelAsyncProcessor with appropriate concurrency limits
+/// - Monitor system resources when using this processor
+/// - Consider the bounded alternatives for production use
+/// 
+/// Ideal only for scenarios with:
+/// - Small task counts (< 100)
+/// - Very lightweight operations
+/// - Sufficient system resources
+/// - Controlled environments where task count is known
 /// </summary>
 public class UnboundedParallelAsyncProcessor : AbstractAsyncProcessor
 {
@@ -17,15 +33,7 @@ public class UnboundedParallelAsyncProcessor : AbstractAsyncProcessor
     {
         // Start ALL tasks immediately without any throttling
         // This provides true unbounded parallelism
-        var tasks = TaskWrappers.Select(taskWrapper => 
-        {
-            var task = taskWrapper.Process(CancellationToken);
-            // Fast-path for already completed tasks
-            if (task.IsCompleted)
-            {
-            }
-            return task;
-        });
+        var tasks = TaskWrappers.Select(taskWrapper => taskWrapper.Process(CancellationToken));
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
     }


### PR DESCRIPTION
## Changes Made:

### 1. Fixed cancellation handling in EnumerableExtensions
- Added proper CancellationToken support to ToIAsyncEnumerable method
- While loop now properly responds to cancellation requests
- Prevents infinite hanging when tasks don't complete

### 2. Fixed semaphore release bug in ParallelExtensions
- Only releases semaphore if it was successfully acquired
- Prevents SemaphoreFullException when cancellation occurs during WaitAsync
- Tracks acquisition state properly in both ProcessAsync overloads

### 3. Removed unnecessary Task.Run wrapping
- Eliminated redundant Task.Run in rate-limited processors
- Removed Task.Run wrapping for already-async operations in ParallelExtensions
- Fixed Task.Run + Task.Yield redundancy (just using Task.Yield where needed)

### 4. Improved unbounded processor implementations
- AsyncEnumerableUnboundedParallelProcessor now truly unbounded (no artificial limits)
- Trusts .NET ThreadPool to manage resources appropriately
- Enhanced documentation warnings about resource risks
- Maintains backward compatibility

### 5. Performance improvements
- Removed wasteful counting/enumeration operations
- Eliminated double context switching from Task.Run + Task.Yield
- Let runtime handle thread pool scheduling optimally

These fixes address the critical issues identified in the deadlock analysis while maintaining the library's performance characteristics and backward compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)