### PR TITLE
chore: define repository line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto eol=lf
+
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.sh text eol=lf


### PR DESCRIPTION
## Summary

- Normalize tracked text files to LF through `.gitattributes`.
- Preserve CRLF for future Windows batch files and LF for shell scripts.
- Run `git add --renormalize .`; tracked blobs were already normalized, so the PR contains no noisy whole-repository rewrite.

## Why

Repository-level attributes make checkouts deterministic across platforms and prevent `core.autocrlf` warnings from obscuring real changes.

## Test plan

- [x] `dotnet test TomLonghurst.EnumerableAsyncProcessor.sln -c Release` (1,074 passed across net8.0 and net9.0)
- [x] `git diff --cached --check`
- [x] `git check-attr text eol -- README.md scripts/AgentLocks.ps1 .gitattributes`
- [x] Commit completed without line-ending warnings

Closes #342