### PR TITLE
fix: build examples in CI

### DIFF
--- a/EnumerableAsyncProcessor.Example/DisposalExample.cs
+++ b/EnumerableAsyncProcessor.Example/DisposalExample.cs
@@ -1,7 +1,6 @@
 #if NET6_0_OR_GREATER
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,19 +28,19 @@ public static class DisposalExample
         // Example 1: The problematic pattern from the issue
         Console.WriteLine("Example 1: PROBLEMATIC - No disposal (resource leak!)");
         var results1 = await ProblematicPatternAsync(new[] { 1, 2, 3, 4, 5 }, CancellationToken.None);
-        Console.WriteLine($"Results: {string.Join(", ", results1.ToList())}");
+        Console.WriteLine($"Results: {string.Join(", ", results1)}");
         Console.WriteLine("⚠️  This pattern leaks resources because the processor is never disposed!\n");
         
         // Example 2: Proper disposal with await using
         Console.WriteLine("Example 2: PROPER - Using await using for automatic disposal");
         var results2 = await ProperPatternWithAwaitUsingAsync(new[] { 1, 2, 3, 4, 5 }, CancellationToken.None);
-        Console.WriteLine($"Results: {string.Join(", ", results2.ToList())}");
+        Console.WriteLine($"Results: {string.Join(", ", results2)}");
         Console.WriteLine("✅ Resources automatically cleaned up with await using\n");
         
         // Example 3: Proper disposal with manual try-finally
         Console.WriteLine("Example 3: PROPER - Manual disposal with try-finally");
         var results3 = await ProperPatternWithManualDisposalAsync(new[] { 1, 2, 3, 4, 5 }, CancellationToken.None);
-        Console.WriteLine($"Results: {string.Join(", ", results3.ToList())}");
+        Console.WriteLine($"Results: {string.Join(", ", results3)}");
         Console.WriteLine("✅ Resources manually cleaned up in finally block\n");
         
         // Example 4: Using the convenience extension (no disposal needed)
@@ -65,23 +64,27 @@ public static class DisposalExample
     /// This is the PROBLEMATIC pattern from the GitHub issue - it leaks resources!
     /// DO NOT USE THIS PATTERN in production code.
     /// </summary>
-    private static async Task<IAsyncEnumerable<int>> ProblematicPatternAsync(int[] input, CancellationToken token)
+    private static async Task<IReadOnlyList<int>> ProblematicPatternAsync(int[] input, CancellationToken token)
     {
         // ⚠️ PROBLEM: The processor is created but never disposed!
         var batchProcessor = input.SelectAsync(static v => TransformAsync(v), token).ProcessInParallel();
-        
-        // This returns the async enumerable, but the processor that created it is never disposed
-        return batchProcessor.GetResultsAsyncEnumerable();
-        
+
+        var results = new List<int>();
+        await foreach (var result in batchProcessor.GetResultsAsyncEnumerable())
+        {
+            results.Add(result);
+        }
+
         // 🔥 RESOURCE LEAK: The processor goes out of scope without being disposed,
         // potentially leaving tasks running and resources uncleaned
+        return results;
     }
     
     /// <summary>
     /// PROPER pattern using await using for automatic disposal.
     /// This is the recommended approach.
     /// </summary>
-    private static async Task<IAsyncEnumerable<int>> ProperPatternWithAwaitUsingAsync(int[] input, CancellationToken token)
+    private static async Task<IReadOnlyList<int>> ProperPatternWithAwaitUsingAsync(int[] input, CancellationToken token)
     {
         // ✅ Create processor with await using for automatic disposal
         await using var processor = input.SelectAsync(static v => TransformAsync(v), token).ProcessInParallel();
@@ -93,17 +96,15 @@ public static class DisposalExample
             results.Add(result);
         }
         
-        // Return as async enumerable
-        return results.ToAsyncEnumerable();
-        
         // ✅ Processor is automatically disposed here due to 'await using'
+        return results;
     }
     
     /// <summary>
     /// PROPER pattern using manual disposal with try-finally.
     /// Use this when you need more control over the disposal timing.
     /// </summary>
-    private static async Task<IAsyncEnumerable<int>> ProperPatternWithManualDisposalAsync(int[] input, CancellationToken token)
+    private static async Task<IReadOnlyList<int>> ProperPatternWithManualDisposalAsync(int[] input, CancellationToken token)
     {
         var processor = input.SelectAsync(static v => TransformAsync(v), token).ProcessInParallel();
         
@@ -116,7 +117,7 @@ public static class DisposalExample
                 results.Add(result);
             }
             
-            return results.ToAsyncEnumerable();
+            return results;
         }
         finally
         {

--- a/EnumerableAsyncProcessor.Pipeline/Modules/BuildExampleProjectsModule.cs
+++ b/EnumerableAsyncProcessor.Pipeline/Modules/BuildExampleProjectsModule.cs
@@ -1,0 +1,32 @@
+using ModularPipelines.Context;
+using ModularPipelines.DotNet.Extensions;
+using ModularPipelines.DotNet.Options;
+using ModularPipelines.Git.Extensions;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+
+namespace EnumerableAsyncProcessor.Pipeline.Modules;
+
+public class BuildExampleProjectsModule : Module<List<CommandResult>>
+{
+    protected override async Task<List<CommandResult>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        var results = new List<CommandResult>();
+
+        foreach (var exampleProjectFile in context
+                     .Git().RootDirectory
+                     .GetFiles(file => file.Path.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)
+                                       && file.Path.Contains("Example", StringComparison.OrdinalIgnoreCase)))
+        {
+            results.Add(await context.DotNet().Build(new DotNetBuildOptions
+            {
+                ProjectSolution = exampleProjectFile.Path,
+                Configuration = "Release",
+            }, cancellationToken: cancellationToken));
+        }
+
+        return results;
+    }
+}

--- a/EnumerableAsyncProcessor.Pipeline/Modules/PackProjectsModule.cs
+++ b/EnumerableAsyncProcessor.Pipeline/Modules/PackProjectsModule.cs
@@ -13,6 +13,7 @@ namespace EnumerableAsyncProcessor.Pipeline.Modules;
 [DependsOn<PackageFilesRemovalModule>]
 [DependsOn<NugetVersionGeneratorModule>]
 [DependsOn<RunUnitTestsModule>]
+[DependsOn<BuildExampleProjectsModule>]
 public class PackProjectsModule : Module<List<CommandResult>>
 {
     protected override async Task<List<CommandResult>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)

--- a/EnumerableAsyncProcessor.Pipeline/Program.cs
+++ b/EnumerableAsyncProcessor.Pipeline/Program.cs
@@ -26,7 +26,8 @@ else
     builder.AddModule<UploadPackagesToNugetModule>();
 }
 
-builder.AddModule<RunUnitTestsModule>()
+builder.AddModule<BuildExampleProjectsModule>()
+    .AddModule<RunUnitTestsModule>()
     .AddModule<NugetVersionGeneratorModule>()
     .AddModule<PackProjectsModule>()
     .AddModule<PackageFilesRemovalModule>()


### PR DESCRIPTION
## Summary

- Replace broken `IAsyncEnumerable.ToList()` and inaccessible `ToAsyncEnumerable()` calls with materialized `IReadOnlyList<int>` results in disposal examples.
- Add `BuildExampleProjectsModule` to the ModularPipelines CI graph.
- Make packaging depend on successful example compilation so API examples cannot silently rot.

## Root cause

The example project was present in the solution but absent from the CI module graph. Disposal examples also depended on conversions that are not public in the v4 API.

## Test plan

- [x] `dotnet build EnumerableAsyncProcessor.Example/EnumerableAsyncProcessor.Example.csproj -c Release`
- [x] `dotnet build EnumerableAsyncProcessor.Pipeline/EnumerableAsyncProcessor.Pipeline.csproj -c Release`
- [x] `dotnet build TomLonghurst.EnumerableAsyncProcessor.sln -c Release`
- [ ] `dotnet test TomLonghurst.EnumerableAsyncProcessor.sln -c Release` — 1,073/1,074 passed; unrelated net8.0 process-wide allocation assertion exceeded its nondeterministic threshold by 5,144 bytes. Follow-up: #346. net9.0 passed.

Closes #341