### PR TITLE
test: make allocation assertion deterministic

### DIFF
--- a/EnumerableAsyncProcessor.UnitTests/TaskWrapperStructValidationTests.cs
+++ b/EnumerableAsyncProcessor.UnitTests/TaskWrapperStructValidationTests.cs
@@ -98,24 +98,23 @@ public class TaskWrapperStructValidationTests
     {
         // This test demonstrates that structs don't allocate on the heap for the wrapper itself
         // Only the TaskCompletionSource instances are heap-allocated
-        
+
         // Arrange & Act
-        GC.Collect();
-        var initialMemory = GC.GetTotalMemory(false);
-        
+        Func<Task> taskFactory = static () => Task.CompletedTask;
+        var initialAllocatedBytes = GC.GetAllocatedBytesForCurrentThread();
+
         var wrappers = new ActionTaskWrapper[1000];
         for (int i = 0; i < wrappers.Length; i++)
         {
             // Only the TaskCompletionSource allocates on the heap, not the wrapper struct
-            wrappers[i] = new ActionTaskWrapper(() => Task.CompletedTask, new TaskCompletionSource());
+            wrappers[i] = new ActionTaskWrapper(taskFactory, new TaskCompletionSource());
         }
-        
-        var finalMemory = GC.GetTotalMemory(false);
-        var allocatedMemory = finalMemory - initialMemory;
-        
+
+        var allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - initialAllocatedBytes;
+
         // Assert - Memory allocation should be only for TaskCompletionSource instances
         // Each struct itself doesn't allocate heap memory
-        await Assert.That(allocatedMemory).IsLessThan(wrappers.Length * 200); // Conservative estimate
+        await Assert.That(allocatedBytes).IsLessThan(wrappers.Length * 200); // Conservative estimate
         var hasNonNullFactory = wrappers[0].TaskFactory != null; // Prevent optimization
         await Assert.That(hasNonNullFactory).IsTrue();
     }


### PR DESCRIPTION
## Summary

- Measure wrapper construction with `GC.GetAllocatedBytesForCurrentThread()` instead of process-wide live heap size.
- Cache the task factory before measurement so the delta covers only the wrapper array and completion sources.
- Retain the existing value-type assertions that detect a regression from structs to heap-allocated wrapper objects.

## Root cause

`GC.GetTotalMemory(false)` includes unrelated allocations from concurrently running TUnit tests and target frameworks. That made the fixed 200 KB threshold nondeterministic even when wrapper behavior was unchanged.

## Test plan

- [x] Two consecutive `dotnet test TomLonghurst.EnumerableAsyncProcessor.sln -c Release` passes
- [x] 1,074/1,074 tests passed per run across concurrent net8.0 and net9.0 execution
- [x] `git diff --check`

Closes #346