### PR TITLE
fix(ci): fail on broken examples

### DIFF
--- a/EnumerableAsyncProcessor.Example/DisposalExample.cs
+++ b/EnumerableAsyncProcessor.Example/DisposalExample.cs
@@ -76,7 +76,7 @@ public static class DisposalExample
         }
 
         // 🔥 RESOURCE LEAK: The processor goes out of scope without being disposed,
-        // potentially leaving tasks running and resources uncleaned
+        // leaving its disposal resources uncleaned
         return results;
     }
     

--- a/EnumerableAsyncProcessor.Pipeline/Modules/BuildExampleProjectsModule.cs
+++ b/EnumerableAsyncProcessor.Pipeline/Modules/BuildExampleProjectsModule.cs
@@ -4,6 +4,7 @@ using ModularPipelines.DotNet.Options;
 using ModularPipelines.Git.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
+using ModularPipelines.Options;
 
 namespace EnumerableAsyncProcessor.Pipeline.Modules;
 
@@ -14,6 +15,10 @@ public class BuildExampleProjectsModule : Module<List<CommandResult>>
         CancellationToken cancellationToken)
     {
         var results = new List<CommandResult>();
+        var executionOptions = new CommandExecutionOptions
+        {
+            ThrowOnNonZeroExitCode = true,
+        };
 
         foreach (var exampleProjectFile in context
                      .Git().RootDirectory
@@ -24,7 +29,7 @@ public class BuildExampleProjectsModule : Module<List<CommandResult>>
             {
                 ProjectSolution = exampleProjectFile.Path,
                 Configuration = "Release",
-            }, cancellationToken: cancellationToken));
+            }, executionOptions: executionOptions, cancellationToken: cancellationToken));
         }
 
         return results;


### PR DESCRIPTION
## Summary

- Make example builds throw on nonzero exit codes so packaging cannot proceed after compilation failure.
- Correct the disposal example's leak description after eager result materialization.

## Context

These changes address both Greptile review threads on #347. That PR auto-merged while the fixes were being tested, so this focused follow-up preserves the reviewed corrections without reverting subsequently merged work.

## Test plan

- [x] `dotnet build EnumerableAsyncProcessor.Example/EnumerableAsyncProcessor.Example.csproj -c Release`
- [x] `dotnet build EnumerableAsyncProcessor.Pipeline/EnumerableAsyncProcessor.Pipeline.csproj -c Release`
- [x] Full suite passed 1,074/1,074 with this exact two-file review-fix delta before splitting it onto current `main`
- [x] `git diff --check`

Follow-up to #347