### PR TITLE
Add cancellation-aware async selectors

### DIFF
--- a/EnumerableAsyncProcessor.UnitTests/CancellationAwareSelectorTests.cs
+++ b/EnumerableAsyncProcessor.UnitTests/CancellationAwareSelectorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using EnumerableAsyncProcessor.Builders;
@@ -83,10 +84,15 @@ public class CancellationAwareSelectorTests
         using var cancellationTokenSource = new CancellationTokenSource();
         var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var interrupted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowCleanupToFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var processor = GetItemsAsync()
             .ForEachAsync(
-                (_, processorToken) => WaitUntilCanceledAsync(processorToken, started, interrupted),
+                (_, processorToken) => WaitUntilCanceledAfterCleanupAsync(
+                    processorToken,
+                    started,
+                    interrupted,
+                    allowCleanupToFinish),
                 cancellationTokenSource.Token)
             .ProcessInParallel();
 
@@ -94,8 +100,41 @@ public class CancellationAwareSelectorTests
         await started.Task.WaitAsync(cancellationToken);
         await cancellationTokenSource.CancelAsync();
 
-        await interrupted.Task.WaitAsync(cancellationToken);
-        await Assert.ThrowsAsync<OperationCanceledException>(() => executeTask);
+        await AssertExecutionWaitsForCleanupAsync(
+            executeTask,
+            interrupted,
+            allowCleanupToFinish,
+            cancellationToken);
+    }
+
+    [Test]
+    public async Task ExternalCancellation_Waits_For_AsyncEnumerable_Result_Selector_Cleanup(CancellationToken cancellationToken)
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interrupted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowCleanupToFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var processor = GetItemsAsync()
+            .SelectAsync(
+                (item, processorToken) => WaitUntilCanceledAfterCleanupAsync(
+                    item,
+                    processorToken,
+                    started,
+                    interrupted,
+                    allowCleanupToFinish),
+                cancellationTokenSource.Token)
+            .ProcessInParallel();
+
+        var executeTask = processor.ExecuteAsync().ToListAsync();
+        await started.Task.WaitAsync(cancellationToken);
+        await cancellationTokenSource.CancelAsync();
+
+        await AssertExecutionWaitsForCleanupAsync(
+            executeTask,
+            interrupted,
+            allowCleanupToFinish,
+            cancellationToken);
     }
 
     private static async Task WaitUntilCanceledAsync(
@@ -125,9 +164,66 @@ public class CancellationAwareSelectorTests
         return result;
     }
 
-    private static async IAsyncEnumerable<int> GetItemsAsync()
+    private static async Task WaitUntilCanceledAfterCleanupAsync(
+        CancellationToken cancellationToken,
+        TaskCompletionSource started,
+        TaskCompletionSource interrupted,
+        TaskCompletionSource allowCleanupToFinish)
+    {
+        started.TrySetResult();
+        try
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            interrupted.TrySetResult();
+            await allowCleanupToFinish.Task;
+            throw;
+        }
+    }
+
+    private static async Task<T> WaitUntilCanceledAfterCleanupAsync<T>(
+        T result,
+        CancellationToken cancellationToken,
+        TaskCompletionSource started,
+        TaskCompletionSource interrupted,
+        TaskCompletionSource allowCleanupToFinish)
+    {
+        await WaitUntilCanceledAfterCleanupAsync(
+            cancellationToken,
+            started,
+            interrupted,
+            allowCleanupToFinish);
+
+        return result;
+    }
+
+    private static async Task AssertExecutionWaitsForCleanupAsync(
+        Task executeTask,
+        TaskCompletionSource interrupted,
+        TaskCompletionSource allowCleanupToFinish,
+        CancellationToken cancellationToken)
+    {
+        await interrupted.Task.WaitAsync(cancellationToken);
+        await Task.Delay(100, cancellationToken);
+
+        try
+        {
+            await Assert.That(executeTask.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            allowCleanupToFinish.TrySetResult();
+        }
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => executeTask);
+    }
+
+    private static async IAsyncEnumerable<int> GetItemsAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         yield return 1;
-        await Task.CompletedTask;
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
     }
 }

--- a/EnumerableAsyncProcessor.UnitTests/CancellationAwareSelectorTests.cs
+++ b/EnumerableAsyncProcessor.UnitTests/CancellationAwareSelectorTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EnumerableAsyncProcessor.Builders;
+using EnumerableAsyncProcessor.Extensions;
+
+namespace EnumerableAsyncProcessor.UnitTests;
+
+public class CancellationAwareSelectorTests
+{
+    [Test]
+    public async Task CancelAll_Interrupts_InFlight_ForEachAsync_Selector(CancellationToken cancellationToken)
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interrupted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var processor = new[] { 1 }
+            .ForEachAsync((_, processorToken) => WaitUntilCanceledAsync(processorToken, started, interrupted))
+            .ProcessInParallel();
+
+        await started.Task.WaitAsync(cancellationToken);
+        processor.CancelAll();
+
+        await interrupted.Task.WaitAsync(cancellationToken);
+        await Assert.ThrowsAsync<TaskCanceledException>(() => processor.WaitAsync());
+    }
+
+    [Test]
+    public async Task CancelAll_Interrupts_InFlight_SelectAsync_Selector(CancellationToken cancellationToken)
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interrupted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var processor = new[] { 1 }
+            .SelectAsync((item, processorToken) => WaitUntilCanceledAsync(item, processorToken, started, interrupted))
+            .ProcessInParallel();
+
+        await started.Task.WaitAsync(cancellationToken);
+        processor.CancelAll();
+
+        await interrupted.Task.WaitAsync(cancellationToken);
+        await Assert.ThrowsAsync<TaskCanceledException>(() => processor.GetResultsAsync());
+    }
+
+    [Test]
+    public async Task CancelAll_Interrupts_ExecutionCount_Selector(CancellationToken cancellationToken)
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interrupted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var processor = AsyncProcessorBuilder.WithExecutionCount(1)
+            .ForEachAsync(processorToken => WaitUntilCanceledAsync(processorToken, started, interrupted))
+            .ProcessInParallel();
+
+        await started.Task.WaitAsync(cancellationToken);
+        processor.CancelAll();
+
+        await interrupted.Task.WaitAsync(cancellationToken);
+        await Assert.ThrowsAsync<TaskCanceledException>(() => processor.WaitAsync());
+    }
+
+    [Test]
+    public async Task DisposeAsync_Interrupts_InFlight_Selector(CancellationToken cancellationToken)
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interrupted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var processor = new[] { 1 }
+            .ForEachAsync((_, processorToken) => WaitUntilCanceledAsync(processorToken, started, interrupted))
+            .ProcessInParallel();
+
+        await started.Task.WaitAsync(cancellationToken);
+        var disposeTask = processor.DisposeAsync().AsTask();
+
+        await interrupted.Task.WaitAsync(cancellationToken);
+        await disposeTask.WaitAsync(cancellationToken);
+    }
+
+    [Test]
+    public async Task ExternalCancellation_Interrupts_AsyncEnumerable_Selector(CancellationToken cancellationToken)
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interrupted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var processor = GetItemsAsync()
+            .ForEachAsync(
+                (_, processorToken) => WaitUntilCanceledAsync(processorToken, started, interrupted),
+                cancellationTokenSource.Token)
+            .ProcessInParallel();
+
+        var executeTask = processor.ExecuteAsync();
+        await started.Task.WaitAsync(cancellationToken);
+        await cancellationTokenSource.CancelAsync();
+
+        await interrupted.Task.WaitAsync(cancellationToken);
+        await Assert.ThrowsAsync<OperationCanceledException>(() => executeTask);
+    }
+
+    private static async Task WaitUntilCanceledAsync(
+        CancellationToken cancellationToken,
+        TaskCompletionSource started,
+        TaskCompletionSource interrupted)
+    {
+        started.TrySetResult();
+        try
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            interrupted.TrySetResult();
+            throw;
+        }
+    }
+
+    private static async Task<T> WaitUntilCanceledAsync<T>(
+        T result,
+        CancellationToken cancellationToken,
+        TaskCompletionSource started,
+        TaskCompletionSource interrupted)
+    {
+        await WaitUntilCanceledAsync(cancellationToken, started, interrupted);
+        return result;
+    }
+
+    private static async IAsyncEnumerable<int> GetItemsAsync()
+    {
+        yield return 1;
+        await Task.CompletedTask;
+    }
+}

--- a/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder.cs
+++ b/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder.cs
@@ -17,6 +17,13 @@ public class ActionAsyncProcessorBuilder
         _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
     }
 
+    public ActionAsyncProcessorBuilder(int count, Func<CancellationToken, Task> taskSelector, CancellationToken cancellationToken)
+    {
+        _count = count;
+        _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _taskSelector = () => taskSelector(_cancellationTokenSource.Token);
+    }
+
     public IAsyncProcessor ProcessInBatches(int batchSize)
     {
         return new BatchAsyncProcessor(batchSize, _count, _taskSelector, _cancellationTokenSource).StartProcessing();

--- a/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder_1.cs
+++ b/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder_1.cs
@@ -17,6 +17,13 @@ public class ActionAsyncProcessorBuilder<TOutput>
         _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
     }
 
+    internal ActionAsyncProcessorBuilder(int count, Func<CancellationToken, Task<TOutput>> taskSelector, CancellationToken cancellationToken)
+    {
+        _count = count;
+        _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _taskSelector = () => taskSelector(_cancellationTokenSource.Token);
+    }
+
     public IAsyncProcessor<TOutput> ProcessInBatches(int batchSize)
     {
         return new ResultBatchAsyncProcessor<TOutput>(batchSize, _count, _taskSelector, _cancellationTokenSource).StartProcessing();

--- a/EnumerableAsyncProcessor/Builders/AsyncEnumerableActionAsyncProcessorBuilder_1.cs
+++ b/EnumerableAsyncProcessor/Builders/AsyncEnumerableActionAsyncProcessorBuilder_1.cs
@@ -19,6 +19,16 @@ public class AsyncEnumerableActionAsyncProcessorBuilder<TInput>
         _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
     }
 
+    public AsyncEnumerableActionAsyncProcessorBuilder(
+        IAsyncEnumerable<TInput> items,
+        Func<TInput, CancellationToken, Task> taskSelector,
+        CancellationToken cancellationToken)
+    {
+        _items = items;
+        _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _taskSelector = item => taskSelector(item, _cancellationTokenSource.Token);
+    }
+
     /// <summary>
     /// Process items in parallel without concurrency limits.
     /// </summary>
@@ -69,7 +79,6 @@ public class AsyncEnumerableActionAsyncProcessorBuilder<TInput>
         return new AsyncEnumerableParallelProcessor<TInput>(
             _items, _taskSelector, maxConcurrency, scheduleOnThreadPool, _cancellationTokenSource);
     }
-    
     
     /// <summary>
     /// Process items one at a time (sequential processing).

--- a/EnumerableAsyncProcessor/Builders/AsyncEnumerableActionAsyncProcessorBuilder_2.cs
+++ b/EnumerableAsyncProcessor/Builders/AsyncEnumerableActionAsyncProcessorBuilder_2.cs
@@ -19,6 +19,16 @@ public class AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>
         _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
     }
 
+    public AsyncEnumerableActionAsyncProcessorBuilder(
+        IAsyncEnumerable<TInput> items,
+        Func<TInput, CancellationToken, Task<TOutput>> taskSelector,
+        CancellationToken cancellationToken)
+    {
+        _items = items;
+        _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _taskSelector = item => taskSelector(item, _cancellationTokenSource.Token);
+    }
+
     /// <summary>
     /// Process items in parallel without concurrency limits and return results.
     /// </summary>
@@ -69,7 +79,6 @@ public class AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>
         return new ResultAsyncEnumerableParallelProcessor<TInput, TOutput>(
             _items, _taskSelector, maxConcurrency, scheduleOnThreadPool, _cancellationTokenSource);
     }
-    
     
     /// <summary>
     /// Process items one at a time and return results in order.

--- a/EnumerableAsyncProcessor/Builders/AsyncEnumerableAsyncProcessorBuilder.cs
+++ b/EnumerableAsyncProcessor/Builders/AsyncEnumerableAsyncProcessorBuilder.cs
@@ -22,6 +22,19 @@ public class AsyncEnumerableAsyncProcessorBuilder<TInput>
         return new AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>(_items, taskSelector, cancellationToken);
     }
 
+    public AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput> SelectAsync<TOutput>(
+        Func<TInput, CancellationToken, Task<TOutput>> taskSelector)
+    {
+        return SelectAsync(taskSelector, CancellationToken.None);
+    }
+
+    public AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput> SelectAsync<TOutput>(
+        Func<TInput, CancellationToken, Task<TOutput>> taskSelector,
+        CancellationToken cancellationToken)
+    {
+        return new AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>(_items, taskSelector, cancellationToken);
+    }
+
     public AsyncEnumerableActionAsyncProcessorBuilder<TInput> ForEachAsync(
         Func<TInput, Task> taskSelector)
     {
@@ -30,6 +43,19 @@ public class AsyncEnumerableAsyncProcessorBuilder<TInput>
 
     public AsyncEnumerableActionAsyncProcessorBuilder<TInput> ForEachAsync(
         Func<TInput, Task> taskSelector, 
+        CancellationToken cancellationToken)
+    {
+        return new AsyncEnumerableActionAsyncProcessorBuilder<TInput>(_items, taskSelector, cancellationToken);
+    }
+
+    public AsyncEnumerableActionAsyncProcessorBuilder<TInput> ForEachAsync(
+        Func<TInput, CancellationToken, Task> taskSelector)
+    {
+        return ForEachAsync(taskSelector, CancellationToken.None);
+    }
+
+    public AsyncEnumerableActionAsyncProcessorBuilder<TInput> ForEachAsync(
+        Func<TInput, CancellationToken, Task> taskSelector,
         CancellationToken cancellationToken)
     {
         return new AsyncEnumerableActionAsyncProcessorBuilder<TInput>(_items, taskSelector, cancellationToken);

--- a/EnumerableAsyncProcessor/Builders/ExecutionCountAsyncProcessorBuilder.cs
+++ b/EnumerableAsyncProcessor/Builders/ExecutionCountAsyncProcessorBuilder.cs
@@ -19,12 +19,32 @@ public class ExecutionCountAsyncProcessorBuilder
         return new ActionAsyncProcessorBuilder<TOutput>(_count, taskSelector, cancellationToken);
     }
 
+    public ActionAsyncProcessorBuilder<TOutput> SelectAsync<TOutput>(Func<CancellationToken, Task<TOutput>> taskSelector)
+    {
+        return SelectAsync(taskSelector, CancellationToken.None);
+    }
+
+    public ActionAsyncProcessorBuilder<TOutput> SelectAsync<TOutput>(Func<CancellationToken, Task<TOutput>> taskSelector, CancellationToken cancellationToken)
+    {
+        return new ActionAsyncProcessorBuilder<TOutput>(_count, taskSelector, cancellationToken);
+    }
+
     public ActionAsyncProcessorBuilder ForEachAsync(Func<Task> taskSelector)
     {
         return ForEachAsync(taskSelector, CancellationToken.None);
     }
 
     public ActionAsyncProcessorBuilder ForEachAsync(Func<Task> taskSelector, CancellationToken cancellationToken)
+    {
+        return new ActionAsyncProcessorBuilder(_count, taskSelector, cancellationToken);
+    }
+
+    public ActionAsyncProcessorBuilder ForEachAsync(Func<CancellationToken, Task> taskSelector)
+    {
+        return ForEachAsync(taskSelector, CancellationToken.None);
+    }
+
+    public ActionAsyncProcessorBuilder ForEachAsync(Func<CancellationToken, Task> taskSelector, CancellationToken cancellationToken)
     {
         return new ActionAsyncProcessorBuilder(_count, taskSelector, cancellationToken);
     }

--- a/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_1.cs
+++ b/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_1.cs
@@ -17,6 +17,13 @@ public class ItemActionAsyncProcessorBuilder<TInput>
         _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
     }
 
+    public ItemActionAsyncProcessorBuilder(IEnumerable<TInput> items, Func<TInput, CancellationToken, Task> taskSelector, CancellationToken cancellationToken)
+    {
+        _items = items;
+        _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _taskSelector = item => taskSelector(item, _cancellationTokenSource.Token);
+    }
+
     public IAsyncProcessor ProcessInBatches(int batchSize)
     {
         return new BatchAsyncProcessor<TInput>(batchSize, _items, _taskSelector, _cancellationTokenSource)

--- a/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_2.cs
+++ b/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_2.cs
@@ -17,6 +17,13 @@ public class ItemActionAsyncProcessorBuilder<TInput, TOutput>
         _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
     }
 
+    internal ItemActionAsyncProcessorBuilder(IEnumerable<TInput> items, Func<TInput, CancellationToken, Task<TOutput>> taskSelector, CancellationToken cancellationToken)
+    {
+        _items = items;
+        _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _taskSelector = item => taskSelector(item, _cancellationTokenSource.Token);
+    }
+
     /// <summary>
     /// Processes items in batches of the specified size.
     /// </summary>

--- a/EnumerableAsyncProcessor/Builders/ItemAsyncProcessorBuilder.cs
+++ b/EnumerableAsyncProcessor/Builders/ItemAsyncProcessorBuilder.cs
@@ -19,12 +19,32 @@ public class ItemAsyncProcessorBuilder<TInput>
         return new ItemActionAsyncProcessorBuilder<TInput, TOutput>(_items, taskSelector, cancellationToken);
     }
 
+    public ItemActionAsyncProcessorBuilder<TInput, TOutput> SelectAsync<TOutput>(Func<TInput, CancellationToken, Task<TOutput>> taskSelector)
+    {
+        return SelectAsync(taskSelector, CancellationToken.None);
+    }
+
+    public ItemActionAsyncProcessorBuilder<TInput, TOutput> SelectAsync<TOutput>(Func<TInput, CancellationToken, Task<TOutput>> taskSelector, CancellationToken cancellationToken)
+    {
+        return new ItemActionAsyncProcessorBuilder<TInput, TOutput>(_items, taskSelector, cancellationToken);
+    }
+
     public ItemActionAsyncProcessorBuilder<TInput> ForEachAsync(Func<TInput, Task> taskSelector)
     {
         return ForEachAsync(taskSelector, CancellationToken.None);
     }
 
     public ItemActionAsyncProcessorBuilder<TInput> ForEachAsync(Func<TInput, Task> taskSelector, CancellationToken cancellationToken)
+    {
+        return new ItemActionAsyncProcessorBuilder<TInput>(_items, taskSelector, cancellationToken);
+    }
+
+    public ItemActionAsyncProcessorBuilder<TInput> ForEachAsync(Func<TInput, CancellationToken, Task> taskSelector)
+    {
+        return ForEachAsync(taskSelector, CancellationToken.None);
+    }
+
+    public ItemActionAsyncProcessorBuilder<TInput> ForEachAsync(Func<TInput, CancellationToken, Task> taskSelector, CancellationToken cancellationToken)
     {
         return new ItemActionAsyncProcessorBuilder<TInput>(_items, taskSelector, cancellationToken);
     }

--- a/EnumerableAsyncProcessor/Extensions/AsyncEnumerableExtensions.cs
+++ b/EnumerableAsyncProcessor/Extensions/AsyncEnumerableExtensions.cs
@@ -17,10 +17,28 @@ public static class AsyncEnumerableExtensions
         return items.ToAsyncProcessorBuilder()
             .SelectAsync(taskSelector, cancellationToken);
     }
+
+    public static AsyncEnumerableActionAsyncProcessorBuilder<T, TOutput> SelectAsync<T, TOutput>(
+        this IAsyncEnumerable<T> items,
+        Func<T, CancellationToken, Task<TOutput>> taskSelector,
+        CancellationToken cancellationToken = default)
+    {
+        return items.ToAsyncProcessorBuilder()
+            .SelectAsync(taskSelector, cancellationToken);
+    }
     
     public static AsyncEnumerableActionAsyncProcessorBuilder<T> ForEachAsync<T>(
         this IAsyncEnumerable<T> items, 
         Func<T, Task> taskSelector, 
+        CancellationToken cancellationToken = default)
+    {
+        return items.ToAsyncProcessorBuilder()
+            .ForEachAsync(taskSelector, cancellationToken);
+    }
+
+    public static AsyncEnumerableActionAsyncProcessorBuilder<T> ForEachAsync<T>(
+        this IAsyncEnumerable<T> items,
+        Func<T, CancellationToken, Task> taskSelector,
         CancellationToken cancellationToken = default)
     {
         return items.ToAsyncProcessorBuilder()

--- a/EnumerableAsyncProcessor/Extensions/EnumerableExtensions.cs
+++ b/EnumerableAsyncProcessor/Extensions/EnumerableExtensions.cs
@@ -27,6 +27,15 @@ public static class EnumerableExtensions
         return items.ToAsyncProcessorBuilder()
             .SelectAsync(taskSelector, cancellationToken);
     }
+
+    /// <summary>
+    /// Creates an async processor builder with a transformation that observes processor cancellation.
+    /// </summary>
+    public static ItemActionAsyncProcessorBuilder<T, TOutput> SelectAsync<T, TOutput>(this IEnumerable<T> items, Func<T, CancellationToken, Task<TOutput>> taskSelector, CancellationToken cancellationToken = default)
+    {
+        return items.ToAsyncProcessorBuilder()
+            .SelectAsync(taskSelector, cancellationToken);
+    }
     
     /// <summary>
     /// Creates an async processor builder for operations that don't return results.
@@ -41,6 +50,15 @@ public static class EnumerableExtensions
     /// Use 'await using var processor = items.ForEachAsync(...).ProcessInParallel();' for automatic disposal.
     /// </remarks>
     public static ItemActionAsyncProcessorBuilder<T> ForEachAsync<T>(this IEnumerable<T> items, Func<T, Task> taskSelector, CancellationToken cancellationToken = default)
+    {
+        return items.ToAsyncProcessorBuilder()
+            .ForEachAsync(taskSelector, cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates an async processor builder with an operation that observes processor cancellation.
+    /// </summary>
+    public static ItemActionAsyncProcessorBuilder<T> ForEachAsync<T>(this IEnumerable<T> items, Func<T, CancellationToken, Task> taskSelector, CancellationToken cancellationToken = default)
     {
         return items.ToAsyncProcessorBuilder()
             .ForEachAsync(taskSelector, cancellationToken);

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableParallelProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableParallelProcessor.cs
@@ -69,27 +69,32 @@ public class AsyncEnumerableParallelProcessor<TInput> : IAsyncEnumerableProcesso
         {
             // Unbounded parallel processing
             var tasks = new List<Task>();
-            
-            await foreach (var item in _items.WithCancellation(cancellationToken).ConfigureAwait(false))
+
+            try
             {
-                var capturedItem = item;
-                
-                Task task;
-                if (_scheduleOnThreadPool)
+                await foreach (var item in _items.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    task = Task.Run(async () => await _taskSelector(capturedItem).ConfigureAwait(false), cancellationToken);
+                    var capturedItem = item;
+
+                    Task task;
+                    if (_scheduleOnThreadPool)
+                    {
+                        task = Task.Run(() => _taskSelector(capturedItem), cancellationToken);
+                    }
+                    else
+                    {
+                        task = _taskSelector(capturedItem);
+                    }
+
+                    tasks.Add(task);
                 }
-                else
-                {
-                    task = _taskSelector(capturedItem);
-                }
-                
-                tasks.Add(task);
             }
-            
-            if (tasks.Count > 0)
+            finally
             {
-                await Task.WhenAll(tasks).ConfigureAwait(false);
+                if (tasks.Count > 0)
+                {
+                    await Task.WhenAll(tasks).ConfigureAwait(false);
+                }
             }
         }
     }

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableParallelProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableParallelProcessor.cs
@@ -91,27 +91,44 @@ public class ResultAsyncEnumerableParallelProcessor<TInput, TOutput> : IAsyncEnu
         else
         {
             // Unbounded parallel processing
-            await foreach (var item in _items.WithCancellation(cancellationToken).ConfigureAwait(false))
+            try
             {
-                var capturedItem = item;
-                
-                Task<TOutput> task;
-                if (_scheduleOnThreadPool)
+                await foreach (var item in _items.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    task = Task.Run(async () => await _taskSelector(capturedItem).ConfigureAwait(false), cancellationToken);
+                    var capturedItem = item;
+
+                    Task<TOutput> task;
+                    if (_scheduleOnThreadPool)
+                    {
+                        task = Task.Run(() => _taskSelector(capturedItem), cancellationToken);
+                    }
+                    else
+                    {
+                        task = _taskSelector(capturedItem);
+                    }
+
+                    tasks.Add(task);
                 }
-                else
+
+                // Yield all results as they complete
+                await foreach (var result in tasks.ToIAsyncEnumerable(cancellationToken).ConfigureAwait(false))
                 {
-                    task = _taskSelector(capturedItem);
+                    yield return result;
                 }
-                
-                tasks.Add(task);
             }
-            
-            // Yield all results as they complete
-            await foreach (var result in tasks.ToIAsyncEnumerable(cancellationToken).ConfigureAwait(false))
+            finally
             {
-                yield return result;
+                if (tasks.Count > 0)
+                {
+                    try
+                    {
+                        await Task.WhenAll(tasks).ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // Preserve the exception already propagating from enumeration or result consumption.
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `CancellationToken`-aware `SelectAsync` and `ForEachAsync` overloads for enumerable, async-enumerable, item, and execution-count builders
- adapt each selector once to the builder's linked processor token, preserving existing wrapper and tokenless paths
- verify in-flight work is interrupted by `CancelAll`, `DisposeAsync`, and external cancellation

## Validation
- full solution restore/build succeeds
- 1,626 tests pass across net8.0, net9.0, and net10.0
- compiled API inspection confirms token-aware and tokenless overloads coexist

Closes #336