### PR TITLE
Use token-bucket timed rate limiting

### DIFF
--- a/EnumerableAsyncProcessor.UnitTests/ValidationRegressionTests.cs
+++ b/EnumerableAsyncProcessor.UnitTests/ValidationRegressionTests.cs
@@ -50,6 +50,9 @@ public class ValidationRegressionTests
         // The result variant previously skipped this validation entirely
         await AssertThrows<ArgumentOutOfRangeException>(() =>
             new[] { 1 }.SelectAsync(i => Task.FromResult(i)).ProcessInParallel(0, TimeSpan.FromSeconds(1)));
+
+        await AssertThrows<ArgumentOutOfRangeException>(() =>
+            new[] { 1 }.SelectAsync(i => Task.FromResult(i)).ProcessInParallel(1, TimeSpan.FromSeconds(1), 0));
     }
 
     [Test]

--- a/EnumerableAsyncProcessor.UnitTests/WorkerPoolBehaviourTests.cs
+++ b/EnumerableAsyncProcessor.UnitTests/WorkerPoolBehaviourTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -131,6 +132,71 @@ public class WorkerPoolBehaviourTests
         await Assert.That(processor.GetEnumerableTasks().Count(x => !x.IsCompleted)).IsEqualTo(0);
 
         await processor.DisposeAsync();
+    }
+
+    [Test, Timeout(10_000)]
+    public async Task Timed_Rate_Limit_Allows_Concurrency_Independent_Of_Permit_Count(CancellationToken cancellationToken)
+    {
+        const int itemCount = 6;
+
+        var startedCount = 0;
+        var allStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var processor = Enumerable.Range(0, itemCount).ToList()
+            .ForEachAsync(async _ =>
+            {
+                if (Interlocked.Increment(ref startedCount) == itemCount)
+                {
+                    allStarted.TrySetResult();
+                }
+
+                await release.Task;
+            }, cancellationToken)
+            .ProcessInParallel(
+                permitsPerWindow: 2,
+                window: TimeSpan.FromMilliseconds(100),
+                maxConcurrency: itemCount);
+
+        try
+        {
+            await allStarted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+
+        await processor.WaitAsync();
+
+        await Assert.That(startedCount).IsEqualTo(itemCount);
+    }
+
+    [Test, Retry(3), Timeout(10_000)]
+    public async Task Timed_Rate_Limit_Does_Not_Exceed_Permits_At_Replenishment(CancellationToken cancellationToken)
+    {
+        const int permitsPerWindow = 3;
+        var window = TimeSpan.FromMilliseconds(200);
+        var startedAt = new ConcurrentBag<TimeSpan>();
+        var stopwatch = Stopwatch.StartNew();
+
+        await using var processor = Enumerable.Range(0, 9).ToList()
+            .ForEachAsync(_ =>
+            {
+                startedAt.Add(stopwatch.Elapsed);
+                return Task.CompletedTask;
+            }, cancellationToken)
+            .ProcessInParallel(permitsPerWindow, window, maxConcurrency: 9);
+
+        await processor.WaitAsync();
+
+        var orderedStarts = startedAt.OrderBy(x => x).ToArray();
+
+        for (var i = permitsPerWindow; i < orderedStarts.Length; i++)
+        {
+            await Assert.That(orderedStarts[i] - orderedStarts[i - permitsPerWindow])
+                .IsGreaterThan(window / 2);
+        }
     }
 
     [Test]

--- a/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder.cs
+++ b/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder.cs
@@ -31,7 +31,16 @@ public class ActionAsyncProcessorBuilder
     
     public IAsyncProcessor ProcessInParallel(int maxConcurrency, TimeSpan timeSpan)
     {
-        return new TimedRateLimitedParallelAsyncProcessor(_count, _taskSelector, maxConcurrency, timeSpan, _cancellationTokenSource).StartProcessing();
+        return ProcessInParallel(maxConcurrency, timeSpan, maxConcurrency);
+    }
+
+    /// <summary>Processes tasks with independent start-rate and concurrency limits.</summary>
+    /// <param name="permitsPerWindow">Maximum operations that may start in each window.</param>
+    /// <param name="window">Rate-limit replenishment window.</param>
+    /// <param name="maxConcurrency">Maximum operations that may remain in flight.</param>
+    public IAsyncProcessor ProcessInParallel(int permitsPerWindow, TimeSpan window, int maxConcurrency)
+    {
+        return new TimedRateLimitedParallelAsyncProcessor(_count, _taskSelector, permitsPerWindow, window, maxConcurrency, _cancellationTokenSource).StartProcessing();
     }
     
     /// <summary>

--- a/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder_1.cs
+++ b/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder_1.cs
@@ -31,7 +31,16 @@ public class ActionAsyncProcessorBuilder<TOutput>
     
     public IAsyncProcessor<TOutput> ProcessInParallel(int maxConcurrency, TimeSpan timeSpan)
     {
-        return new ResultTimedRateLimitedParallelAsyncProcessor<TOutput>(_count, _taskSelector, maxConcurrency, timeSpan, _cancellationTokenSource).StartProcessing();
+        return ProcessInParallel(maxConcurrency, timeSpan, maxConcurrency);
+    }
+
+    /// <summary>Processes tasks with independent start-rate and concurrency limits.</summary>
+    /// <param name="permitsPerWindow">Maximum operations that may start in each window.</param>
+    /// <param name="window">Rate-limit replenishment window.</param>
+    /// <param name="maxConcurrency">Maximum operations that may remain in flight.</param>
+    public IAsyncProcessor<TOutput> ProcessInParallel(int permitsPerWindow, TimeSpan window, int maxConcurrency)
+    {
+        return new ResultTimedRateLimitedParallelAsyncProcessor<TOutput>(_count, _taskSelector, permitsPerWindow, window, maxConcurrency, _cancellationTokenSource).StartProcessing();
     }
     
     /// <summary>

--- a/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_1.cs
+++ b/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_1.cs
@@ -32,7 +32,16 @@ public class ItemActionAsyncProcessorBuilder<TInput>
     
     public IAsyncProcessor ProcessInParallel(int maxConcurrency, TimeSpan timeSpan)
     {
-        return new TimedRateLimitedParallelAsyncProcessor<TInput>(_items, _taskSelector, maxConcurrency, timeSpan, _cancellationTokenSource)
+        return ProcessInParallel(maxConcurrency, timeSpan, maxConcurrency);
+    }
+
+    /// <summary>Processes items with independent start-rate and concurrency limits.</summary>
+    /// <param name="permitsPerWindow">Maximum operations that may start in each window.</param>
+    /// <param name="window">Rate-limit replenishment window.</param>
+    /// <param name="maxConcurrency">Maximum operations that may remain in flight.</param>
+    public IAsyncProcessor ProcessInParallel(int permitsPerWindow, TimeSpan window, int maxConcurrency)
+    {
+        return new TimedRateLimitedParallelAsyncProcessor<TInput>(_items, _taskSelector, permitsPerWindow, window, maxConcurrency, _cancellationTokenSource)
             .StartProcessing();
     }
     

--- a/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_2.cs
+++ b/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_2.cs
@@ -52,7 +52,19 @@ public class ItemActionAsyncProcessorBuilder<TInput, TOutput>
     /// </remarks>
     public IAsyncProcessor<TOutput> ProcessInParallel(int maxConcurrency, TimeSpan timeSpan)
     {
-        return new ResultTimedRateLimitedParallelAsyncProcessor<TInput, TOutput>(_items, _taskSelector, maxConcurrency, timeSpan, _cancellationTokenSource).StartProcessing();
+        return ProcessInParallel(maxConcurrency, timeSpan, maxConcurrency);
+    }
+
+    /// <summary>
+    /// Processes items with independent start-rate and concurrency limits.
+    /// </summary>
+    /// <param name="permitsPerWindow">Maximum operations that may start in each window.</param>
+    /// <param name="window">Rate-limit replenishment window.</param>
+    /// <param name="maxConcurrency">Maximum operations that may remain in flight.</param>
+    /// <returns>An async processor that implements IDisposable and IAsyncDisposable.</returns>
+    public IAsyncProcessor<TOutput> ProcessInParallel(int permitsPerWindow, TimeSpan window, int maxConcurrency)
+    {
+        return new ResultTimedRateLimitedParallelAsyncProcessor<TInput, TOutput>(_items, _taskSelector, permitsPerWindow, window, maxConcurrency, _cancellationTokenSource).StartProcessing();
     }
     
     /// <summary>

--- a/EnumerableAsyncProcessor/EnumerableAsyncProcessor.csproj
+++ b/EnumerableAsyncProcessor/EnumerableAsyncProcessor.csproj
@@ -29,6 +29,7 @@
         <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath="\" />
         
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All"/>
+        <PackageReference Include="System.Threading.RateLimiting" Version="10.0.10" />
 
     </ItemGroup>
 

--- a/EnumerableAsyncProcessor/RunnableProcessors/ParallelAsyncProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ParallelAsyncProcessor.cs
@@ -46,6 +46,6 @@ public class ParallelAsyncProcessor : AbstractAsyncProcessor
 
         // Throttled processing runs on a fixed worker pool: P worker tasks instead of
         // one queued task, closure and semaphore wait per item
-        await WorkerPool.ProcessAsync(TaskWrappers, _maxConcurrency.Value, minimumIterationTime: null, CancellationToken).ConfigureAwait(false);
+        await WorkerPool.ProcessAsync(TaskWrappers, _maxConcurrency.Value, rateLimiter: null, CancellationToken).ConfigureAwait(false);
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/ParallelAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ParallelAsyncProcessor_1.cs
@@ -46,6 +46,6 @@ public class ParallelAsyncProcessor<TInput> : AbstractAsyncProcessor<TInput>
 
         // Throttled processing runs on a fixed worker pool: P worker tasks instead of
         // one queued task, closure and semaphore wait per item
-        await WorkerPool.ProcessAsync(TaskWrappers, _maxConcurrency.Value, minimumIterationTime: null, CancellationToken).ConfigureAwait(false);
+        await WorkerPool.ProcessAsync(TaskWrappers, _maxConcurrency.Value, rateLimiter: null, CancellationToken).ConfigureAwait(false);
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultParallelAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultParallelAsyncProcessor_1.cs
@@ -46,6 +46,6 @@ public class ResultParallelAsyncProcessor<TOutput> : ResultAbstractAsyncProcesso
 
         // Throttled processing runs on a fixed worker pool: P worker tasks instead of
         // one queued task, closure and semaphore wait per item
-        await WorkerPool.ProcessAsync(TaskWrappers, _maxConcurrency.Value, minimumIterationTime: null, CancellationToken).ConfigureAwait(false);
+        await WorkerPool.ProcessAsync(TaskWrappers, _maxConcurrency.Value, rateLimiter: null, CancellationToken).ConfigureAwait(false);
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultParallelAsyncProcessor_2.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultParallelAsyncProcessor_2.cs
@@ -46,6 +46,6 @@ public class ResultParallelAsyncProcessor<TInput, TOutput> : ResultAbstractAsync
 
         // Throttled processing runs on a fixed worker pool: P worker tasks instead of
         // one queued task, closure and semaphore wait per item
-        await WorkerPool.ProcessAsync(TaskWrappers, _maxConcurrency.Value, minimumIterationTime: null, CancellationToken).ConfigureAwait(false);
+        await WorkerPool.ProcessAsync(TaskWrappers, _maxConcurrency.Value, rateLimiter: null, CancellationToken).ConfigureAwait(false);
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultTimedRateLimitedParallelAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultTimedRateLimitedParallelAsyncProcessor_1.cs
@@ -5,20 +5,23 @@ namespace EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors;
 
 public class ResultTimedRateLimitedParallelAsyncProcessor<TOutput> : ResultAbstractAsyncProcessor<TOutput>
 {
-    private readonly int _levelsOfParallelism;
-    private readonly TimeSpan _timeSpan;
+    private readonly int _permitsPerWindow;
+    private readonly TimeSpan _window;
+    private readonly int _maxConcurrency;
 
-    internal ResultTimedRateLimitedParallelAsyncProcessor(int count, Func<Task<TOutput>> taskSelector, int levelsOfParallelism, TimeSpan timeSpan, CancellationTokenSource cancellationTokenSource) : base(count, taskSelector, cancellationTokenSource)
+    internal ResultTimedRateLimitedParallelAsyncProcessor(int count, Func<Task<TOutput>> taskSelector, int permitsPerWindow, TimeSpan window, int maxConcurrency, CancellationTokenSource cancellationTokenSource) : base(count, taskSelector, cancellationTokenSource)
     {
-        ValidationHelper.ThrowIfNegativeOrZero(levelsOfParallelism);
-        ValidationHelper.ThrowIfNegative(timeSpan);
+        ValidationHelper.ThrowIfNegativeOrZero(permitsPerWindow);
+        ValidationHelper.ThrowIfNegative(window);
+        ValidationHelper.ThrowIfNegativeOrZero(maxConcurrency);
 
-        _levelsOfParallelism = levelsOfParallelism;
-        _timeSpan = timeSpan;
+        _permitsPerWindow = permitsPerWindow;
+        _window = window;
+        _maxConcurrency = maxConcurrency;
     }
 
     internal override Task Process()
     {
-        return WorkerPool.ProcessAsync(TaskWrappers, _levelsOfParallelism, minimumIterationTime: _timeSpan, CancellationToken);
+        return WorkerPool.ProcessRateLimitedAsync(TaskWrappers, _maxConcurrency, _permitsPerWindow, _window, CancellationToken);
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultTimedRateLimitedParallelAsyncProcessor_2.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultTimedRateLimitedParallelAsyncProcessor_2.cs
@@ -5,20 +5,23 @@ namespace EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors;
 
 public class ResultTimedRateLimitedParallelAsyncProcessor<TInput, TOutput> : ResultAbstractAsyncProcessor<TInput, TOutput>
 {
-    private readonly int _levelsOfParallelism;
-    private readonly TimeSpan _timeSpan;
+    private readonly int _permitsPerWindow;
+    private readonly TimeSpan _window;
+    private readonly int _maxConcurrency;
 
-    internal ResultTimedRateLimitedParallelAsyncProcessor(IEnumerable<TInput> items, Func<TInput, Task<TOutput>> taskSelector, int levelsOfParallelism, TimeSpan timeSpan, CancellationTokenSource cancellationTokenSource) : base(items, taskSelector, cancellationTokenSource)
+    internal ResultTimedRateLimitedParallelAsyncProcessor(IEnumerable<TInput> items, Func<TInput, Task<TOutput>> taskSelector, int permitsPerWindow, TimeSpan window, int maxConcurrency, CancellationTokenSource cancellationTokenSource) : base(items, taskSelector, cancellationTokenSource)
     {
-        ValidationHelper.ThrowIfNegativeOrZero(levelsOfParallelism);
-        ValidationHelper.ThrowIfNegative(timeSpan);
+        ValidationHelper.ThrowIfNegativeOrZero(permitsPerWindow);
+        ValidationHelper.ThrowIfNegative(window);
+        ValidationHelper.ThrowIfNegativeOrZero(maxConcurrency);
 
-        _levelsOfParallelism = levelsOfParallelism;
-        _timeSpan = timeSpan;
+        _permitsPerWindow = permitsPerWindow;
+        _window = window;
+        _maxConcurrency = maxConcurrency;
     }
 
     internal override Task Process()
     {
-        return WorkerPool.ProcessAsync(TaskWrappers, _levelsOfParallelism, minimumIterationTime: _timeSpan, CancellationToken);
+        return WorkerPool.ProcessRateLimitedAsync(TaskWrappers, _maxConcurrency, _permitsPerWindow, _window, CancellationToken);
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/TimedRateLimitedParallelAsyncProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/TimedRateLimitedParallelAsyncProcessor.cs
@@ -5,20 +5,23 @@ namespace EnumerableAsyncProcessor.RunnableProcessors;
 
 public class TimedRateLimitedParallelAsyncProcessor : AbstractAsyncProcessor
 {
-    private readonly int _levelsOfParallelism;
-    private readonly TimeSpan _timeSpan;
+    private readonly int _permitsPerWindow;
+    private readonly TimeSpan _window;
+    private readonly int _maxConcurrency;
 
-    internal TimedRateLimitedParallelAsyncProcessor(int count, Func<Task> taskSelector, int levelsOfParallelism, TimeSpan timeSpan, CancellationTokenSource cancellationTokenSource) : base(count, taskSelector, cancellationTokenSource)
+    internal TimedRateLimitedParallelAsyncProcessor(int count, Func<Task> taskSelector, int permitsPerWindow, TimeSpan window, int maxConcurrency, CancellationTokenSource cancellationTokenSource) : base(count, taskSelector, cancellationTokenSource)
     {
-        ValidationHelper.ThrowIfNegativeOrZero(levelsOfParallelism);
-        ValidationHelper.ThrowIfNegative(timeSpan);
+        ValidationHelper.ThrowIfNegativeOrZero(permitsPerWindow);
+        ValidationHelper.ThrowIfNegative(window);
+        ValidationHelper.ThrowIfNegativeOrZero(maxConcurrency);
 
-        _levelsOfParallelism = levelsOfParallelism;
-        _timeSpan = timeSpan;
+        _permitsPerWindow = permitsPerWindow;
+        _window = window;
+        _maxConcurrency = maxConcurrency;
     }
 
     internal override Task Process()
     {
-        return WorkerPool.ProcessAsync(TaskWrappers, _levelsOfParallelism, minimumIterationTime: _timeSpan, CancellationToken);
+        return WorkerPool.ProcessRateLimitedAsync(TaskWrappers, _maxConcurrency, _permitsPerWindow, _window, CancellationToken);
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/TimedRateLimitedParallelAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/TimedRateLimitedParallelAsyncProcessor_1.cs
@@ -5,20 +5,23 @@ namespace EnumerableAsyncProcessor.RunnableProcessors;
 
 public class TimedRateLimitedParallelAsyncProcessor<TInput> : AbstractAsyncProcessor<TInput>
 {
-    private readonly int _levelsOfParallelism;
-    private readonly TimeSpan _timeSpan;
+    private readonly int _permitsPerWindow;
+    private readonly TimeSpan _window;
+    private readonly int _maxConcurrency;
 
-    internal TimedRateLimitedParallelAsyncProcessor(IEnumerable<TInput> items, Func<TInput, Task> taskSelector, int levelsOfParallelism, TimeSpan timeSpan, CancellationTokenSource cancellationTokenSource) : base(items, taskSelector, cancellationTokenSource)
+    internal TimedRateLimitedParallelAsyncProcessor(IEnumerable<TInput> items, Func<TInput, Task> taskSelector, int permitsPerWindow, TimeSpan window, int maxConcurrency, CancellationTokenSource cancellationTokenSource) : base(items, taskSelector, cancellationTokenSource)
     {
-        ValidationHelper.ThrowIfNegativeOrZero(levelsOfParallelism);
-        ValidationHelper.ThrowIfNegative(timeSpan);
+        ValidationHelper.ThrowIfNegativeOrZero(permitsPerWindow);
+        ValidationHelper.ThrowIfNegative(window);
+        ValidationHelper.ThrowIfNegativeOrZero(maxConcurrency);
 
-        _levelsOfParallelism = levelsOfParallelism;
-        _timeSpan = timeSpan;
+        _permitsPerWindow = permitsPerWindow;
+        _window = window;
+        _maxConcurrency = maxConcurrency;
     }
 
     internal override Task Process()
     {
-        return WorkerPool.ProcessAsync(TaskWrappers, _levelsOfParallelism, minimumIterationTime: _timeSpan, CancellationToken);
+        return WorkerPool.ProcessRateLimitedAsync(TaskWrappers, _maxConcurrency, _permitsPerWindow, _window, CancellationToken);
     }
 }

--- a/EnumerableAsyncProcessor/WorkerPool.cs
+++ b/EnumerableAsyncProcessor/WorkerPool.cs
@@ -1,3 +1,5 @@
+using System.Threading.RateLimiting;
+
 namespace EnumerableAsyncProcessor;
 
 /// <summary>
@@ -7,14 +9,10 @@ namespace EnumerableAsyncProcessor;
 /// </summary>
 internal static class WorkerPool
 {
-    /// <param name="minimumIterationTime">
-    /// When set, each worker holds its slot for at least this long per item, which caps throughput
-    /// at (workerCount / minimumIterationTime) operations for the timed rate-limited processors.
-    /// </param>
     internal static Task ProcessAsync<TWrapper>(
         TWrapper[] taskWrappers,
         int workerCount,
-        TimeSpan? minimumIterationTime,
+        RateLimiter? rateLimiter,
         CancellationToken cancellationToken) where TWrapper : ITaskWrapper
     {
         workerCount = Math.Min(workerCount, taskWrappers.Length);
@@ -42,22 +40,49 @@ internal static class WorkerPool
                         return;
                     }
 
+                    if (rateLimiter is not null)
+                    {
+                        using var lease = await rateLimiter.AcquireAsync(1, cancellationToken).ConfigureAwait(false);
+
+                        if (!lease.IsAcquired)
+                        {
+                            throw new InvalidOperationException("The rate limiter could not acquire a permit.");
+                        }
+                    }
+
                     // Process never throws; it completes the item's TaskCompletionSource instead,
                     // so one failed item cannot stop the worker from draining the rest.
-                    var processTask = taskWrappers[index].Process(cancellationToken);
-
-                    if (minimumIterationTime is { } minimumTime)
-                    {
-                        await Task.WhenAll(processTask, Task.Delay(minimumTime, cancellationToken)).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        await processTask.ConfigureAwait(false);
-                    }
+                    await taskWrappers[index].Process(cancellationToken).ConfigureAwait(false);
                 }
             }, cancellationToken);
         }
 
         return Task.WhenAll(workers);
+    }
+
+    internal static async Task ProcessRateLimitedAsync<TWrapper>(
+        TWrapper[] taskWrappers,
+        int workerCount,
+        int permitsPerWindow,
+        TimeSpan window,
+        CancellationToken cancellationToken) where TWrapper : ITaskWrapper
+    {
+        if (window == TimeSpan.Zero)
+        {
+            await ProcessAsync(taskWrappers, workerCount, rateLimiter: null, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        using var rateLimiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+        {
+            TokenLimit = permitsPerWindow,
+            TokensPerPeriod = permitsPerWindow,
+            ReplenishmentPeriod = window,
+            AutoReplenishment = true,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            QueueLimit = workerCount
+        });
+
+        await ProcessAsync(taskWrappers, workerCount, rateLimiter, cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Summary

- replace per-worker minimum dwell timing with a shared `TokenBucketRateLimiter`
- limit operation starts to a configured permit count per replenishment window
- add a three-argument builder overload that separates permits per window from maximum in-flight concurrency
- preserve the existing two-argument overload by mapping its parallelism value to both limits
- keep zero-duration windows unthrottled and retain cancellation/validation behavior

## Impact

Long-running operations no longer delay future rate permits when callers configure a larger concurrency cap. Timed processors now model start rate independently from work duration, while existing call sites remain source-compatible.

## Validation

- legacy timed rate-limit tests pass
- added timing-tolerant coverage for independent concurrency, replenishment burst size, and max-concurrency validation
- `dotnet test`: 1,617 tests passed across net8.0, net9.0, and net10.0

Closes #335