### PR TITLE
refactor!: freeze a clean v4 public API surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ dotnet run --project EnumerableAsyncProcessor.UnitTests -f net10.0 -- --treenode
 
 TUnit test projects compile to executables; VSTest-style `dotnet test --filter` does not work. See the `tunit-testing` skill for full filter syntax.
 
+**TUnit itself depends on this library.** `TUnit.Engine` is compiled against EnumerableAsyncProcessor v3, and the locally built assembly shadows the copy TUnit shipped with (same assembly identity), so removing or changing a public member that TUnit.Engine binds to crashes test discovery with `MissingMethodException` before any test runs. The exact signatures TUnit needs are pinned by `V3BinaryCompatibilityTests` and marked as binary-compat members in the source — do not remove them until TUnit ships a build compiled against v4.
+
 CI (`.github/workflows/dotnet.yml`) runs the `EnumerableAsyncProcessor.Pipeline` project (a ModularPipelines app, `dotnet run -c Release` from that directory), which builds, tests, packs, and — on `main` — publishes to NuGet. Versioning comes from GitVersion (`GitVersion.yml` pins `next-version: 4.0.0`; keep that file present, its absence makes ModularPipelines generate a Mainline config that crashes on GitHub PR merge commits).
 
 ## Architecture
@@ -45,17 +47,17 @@ Processor classes vary along three axes, reflected in naming:
 
 - **Input**: with items (`<TInput>`) vs. execution-count only (non-generic).
 - **Output**: `Result*`-prefixed classes (in `RunnableProcessors/ResultProcessors/`) return values via `IAsyncProcessor<TOutput>` (`GetResultsAsync()`, `GetResultsAsyncEnumerable()`, `GetEnumerableTasks()`); unprefixed classes are fire-and-await (`WaitAsync()`).
-- **Strategy**: `OneAtATime`, `Batch`, `Parallel`, `RateLimitedParallel`, `TimedRateLimitedParallel`.
+- **Strategy**: `OneAtATime`, `Batch`, `Parallel`, `TimedRateLimitedParallel`.
 
-`RunnableProcessors/AsyncEnumerable/` holds parallel variants for `IAsyncEnumerable<T>` sources. File-name suffixes `_1`/`_2` distinguish generic arity (e.g. `BatchAsyncProcessor_1.cs` is `BatchAsyncProcessor<TInput>`).
+`RunnableProcessors/AsyncEnumerable/` holds the `IAsyncEnumerable<T>`-source variants (Parallel, OneAtATime, Batch). File-name suffixes `_1`/`_2` distinguish generic arity (e.g. `BatchAsyncProcessor_1.cs` is `BatchAsyncProcessor<TInput>`).
 
 ### Core mechanics (read these before changing behavior)
 
 - **`ProcessorLifecycle.cs`**: owns start/cancel/dispose shared by both base-class hierarchies. `AbstractAsyncProcessorBase` (void) and `ResultAbstractAsyncProcessorBase` (results) cannot share an ancestor because they fan out to differently typed `TaskCompletionSource` lists, so both delegate to this class. Cancellation is registered in `Start`, not the constructor, so a pre-cancelled token can never fire on a partially built instance. `DisposeAsync` waits up to 30 seconds for in-flight tasks; sync `Dispose` cancels without blocking.
 - **TCS-per-item**: each item gets a `TaskCompletionSource`; `TaskWrapper.Process` never throws — it completes the item's TCS with the failure/cancellation instead, so one failed item cannot kill the run or leave awaiters hanging.
-- **`WorkerPool.cs`**: rate-limited processors run a fixed pool of worker loops claiming items via `Interlocked.Increment` (P `Task.Run` tasks total, not N throttled tasks + semaphore). `minimumIterationTime` is how timed rate limiting is implemented: each worker holds its slot for at least that duration per item.
+- **`WorkerPool.cs`**: rate-limited processors run a fixed pool of worker loops claiming items via `Interlocked.Increment` (P `Task.Run` tasks total, not N throttled tasks + semaphore). Timed rate limiting is a shared `TokenBucketRateLimiter` (`System.Threading.RateLimiting`): workers acquire a permit before starting each item, so `permitsPerWindow`/`window` bound the start rate independently of `maxConcurrency`.
 - **Multi-targeting**: `EnumerableExtensions.ToIAsyncEnumerable` uses `Task.WhenEach` on `NET9_0_OR_GREATER` and a completion-order-bucket fallback otherwise. The test project targets `net8.0` specifically to exercise the fallback path — don't drop that TFM.
 
 ### Disposal contract
 
-All processors implement `IDisposable`/`IAsyncDisposable`; the README documents the patterns users rely on (`await using`, safe double/early disposal). The builder extension shortcuts on `IAsyncEnumerable<T>` dispose internally; processors returned from the builder pattern are the caller's responsibility. Preserve these semantics — there are dedicated regression tests (`DisposalRegressionTests`, `ExceptionFidelityTests`, `InputEnumerationRegressionTests`).
+All processors implement `IDisposable`/`IAsyncDisposable`; the README documents the patterns users rely on (`await using`, safe double/early disposal). `IAsyncEnumerableProcessor` implementations are single-use and additionally dispose their internal linked `CancellationTokenSource` when `ExecuteAsync` completes; `IAsyncProcessor` objects returned from the builder pattern are the caller's responsibility. Preserve these semantics — there are dedicated regression tests (`DisposalRegressionTests`, `ExceptionFidelityTests`, `InputEnumerationRegressionTests`).

--- a/EnumerableAsyncProcessor.Example/ProcessInParallelExample.cs
+++ b/EnumerableAsyncProcessor.Example/ProcessInParallelExample.cs
@@ -15,10 +15,10 @@ public static class ProcessInParallelExample
         Console.WriteLine("ProcessInParallel Extension Examples");
         Console.WriteLine("====================================\n");
         
-        // Example 1: Simple parallel processing without transformation
-        Console.WriteLine("Example 1: Simple parallel processing (no transformation needed!)");
+        // Example 1: Simple parallel processing with an identity transformation
+        Console.WriteLine("Example 1: Simple parallel processing");
         var asyncEnumerable1 = GenerateAsyncEnumerable(5);
-        IEnumerable<int> results1 = await asyncEnumerable1.ProcessInParallel();  // <-- This is the simple extension!
+        IEnumerable<int> results1 = await asyncEnumerable1.ProcessInParallel(item => Task.FromResult(item));
         Console.WriteLine($"Results: {string.Join(", ", results1)}");
         
         // Example 2: Parallel processing with transformation

--- a/EnumerableAsyncProcessor.UnitTests/AsyncEnumerableParallelExtensionsTests.cs
+++ b/EnumerableAsyncProcessor.UnitTests/AsyncEnumerableParallelExtensionsTests.cs
@@ -33,23 +33,12 @@ public class AsyncEnumerableParallelExtensionsTests
     }
 
     [Test]
-    public async Task ProcessInParallel_WithoutTransformation_ReturnsAllItems()
-    {
-        var asyncEnumerable = GenerateAsyncEnumerable(10);
-        
-        var results = await asyncEnumerable.ProcessInParallel();
-        
-        await Assert.That(results.Count()).IsEqualTo(10);
-        await Assert.That(results.OrderBy(x => x)).IsEquivalentTo(Enumerable.Range(1, 10));
-    }
-
-    [Test]
     public async Task ProcessInParallel_WithMaxConcurrency_ReturnsAllItems()
     {
         var asyncEnumerable = GenerateAsyncEnumerable(20);
-        
-        var results = await asyncEnumerable.ProcessInParallel(5);
-        
+
+        var results = await asyncEnumerable.ProcessInParallel(item => Task.FromResult(item), 5);
+
         await Assert.That(results.Count()).IsEqualTo(20);
         await Assert.That(results.OrderBy(x => x)).IsEquivalentTo(Enumerable.Range(1, 20));
     }
@@ -94,7 +83,7 @@ public class AsyncEnumerableParallelExtensionsTests
         using var cts = new CancellationTokenSource();
         var asyncEnumerable = GenerateDelayedAsyncEnumerable(100, 50);
         
-        var task = asyncEnumerable.ProcessInParallel(cancellationToken: cts.Token);
+        var task = asyncEnumerable.ProcessInParallel(item => Task.FromResult(item), cancellationToken: cts.Token);
         
         // Cancel after a short delay
         cts.CancelAfter(100);
@@ -160,23 +149,10 @@ public class AsyncEnumerableParallelExtensionsTests
     public async Task ProcessInParallel_EmptyEnumerable_ReturnsEmptyResult()
     {
         var asyncEnumerable = GenerateAsyncEnumerable(0);
-        
-        var results = await asyncEnumerable.ProcessInParallel();
-        
-        await Assert.That(results.Count()).IsEqualTo(0);
-    }
 
-    [Test]
-    public async Task ProcessInParallel_WithScheduleOnThreadPool_ProcessesAllItems()
-    {
-        var asyncEnumerable = GenerateAsyncEnumerable(10);
-        
-        var results = await asyncEnumerable.ProcessInParallel(
-            maxConcurrency: null,
-            scheduleOnThreadPool: true);
-        
-        await Assert.That(results.Count()).IsEqualTo(10);
-        await Assert.That(results.OrderBy(x => x)).IsEquivalentTo(Enumerable.Range(1, 10));
+        var results = await asyncEnumerable.ProcessInParallel(item => Task.FromResult(item));
+
+        await Assert.That(results.Count()).IsEqualTo(0);
     }
 
     [Test]

--- a/EnumerableAsyncProcessor.UnitTests/DisposalRegressionTests.cs
+++ b/EnumerableAsyncProcessor.UnitTests/DisposalRegressionTests.cs
@@ -161,6 +161,50 @@ public class DisposalRegressionTests
         }
     }
 
+    [Test, Timeout(30_000)]
+    public async Task AsyncEnumerable_Processor_Dispose_During_Execution_Cancels_Processing(CancellationToken cancellationToken)
+    {
+        var firstItemStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var processor = InfiniteAsyncEnumerable()
+            .ForEachAsync(async _ =>
+            {
+                firstItemStarted.TrySetResult();
+                await Task.Yield();
+            })
+            .ProcessInParallel(maxConcurrency: 1);
+
+        var executeTask = processor.ExecuteAsync();
+        await firstItemStarted.Task;
+
+        processor.Dispose();
+
+        Exception? caught = null;
+        try
+        {
+            await executeTask.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            caught = exception;
+        }
+
+        // A TimeoutException here means disposal did not cancel the in-flight run.
+        await Assert.That(caught is OperationCanceledException).IsTrue();
+    }
+
+    private static async IAsyncEnumerable<int> InfiniteAsyncEnumerable(
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var i = 0;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return i++;
+            await Task.Yield();
+        }
+    }
+
     private static async IAsyncEnumerable<int> GenerateAsyncEnumerable(int count)
     {
         for (var i = 0; i < count; i++)

--- a/EnumerableAsyncProcessor.UnitTests/DisposalRegressionTests.cs
+++ b/EnumerableAsyncProcessor.UnitTests/DisposalRegressionTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using EnumerableAsyncProcessor.Extensions;
 
@@ -126,5 +128,45 @@ public class DisposalRegressionTests
         processor.CancelAll();
 
         await Assert.That(processor.GetEnumerableTasks().Count(x => x.IsCompletedSuccessfully)).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task AsyncEnumerable_Processor_Disposal_Is_Idempotent_After_Execution()
+    {
+        var processedCount = 0;
+
+        var processor = GenerateAsyncEnumerable(5)
+            .ForEachAsync(_ =>
+            {
+                Interlocked.Increment(ref processedCount);
+                return Task.CompletedTask;
+            })
+            .ProcessInParallel(maxConcurrency: 2);
+
+        await processor.ExecuteAsync();
+
+        // ExecuteAsync disposes internal resources on completion; explicit disposal stays safe.
+        await processor.DisposeAsync();
+        processor.Dispose();
+
+        await Assert.That(processedCount).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task AsyncEnumerable_Result_Processor_Supports_Await_Using_Without_Execution()
+    {
+        await using (GenerateAsyncEnumerable(3).SelectAsync(i => Task.FromResult(i)).ProcessInParallel(2))
+        {
+            // Never executed - disposal alone must not throw.
+        }
+    }
+
+    private static async IAsyncEnumerable<int> GenerateAsyncEnumerable(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            await Task.Yield();
+            yield return i;
+        }
     }
 }

--- a/EnumerableAsyncProcessor.UnitTests/DisposalRegressionTests.cs
+++ b/EnumerableAsyncProcessor.UnitTests/DisposalRegressionTests.cs
@@ -193,6 +193,50 @@ public class DisposalRegressionTests
         await Assert.That(caught is OperationCanceledException).IsTrue();
     }
 
+    [Test, Timeout(30_000)]
+    public async Task AsyncEnumerable_Processor_DisposeAsync_Waits_For_InFlight_Selector(CancellationToken cancellationToken)
+    {
+        var firstItemStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseItem = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var itemsCompleted = 0;
+
+        var processor = InfiniteAsyncEnumerable()
+            .ForEachAsync(async _ =>
+            {
+                firstItemStarted.TrySetResult();
+                await releaseItem.Task;
+                Interlocked.Increment(ref itemsCompleted);
+            })
+            .ProcessInParallel(maxConcurrency: 1);
+
+        var executeTask = processor.ExecuteAsync();
+        await firstItemStarted.Task;
+
+        var disposeTask = processor.DisposeAsync().AsTask();
+
+        // The selector ignores cancellation and is still blocked, so disposal must still be waiting.
+        await Assert.That(disposeTask.IsCompleted).IsFalse();
+
+        releaseItem.TrySetResult();
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        // At least the in-flight item finished before disposal returned; the worker may also
+        // drain one already-buffered item before it observes cancellation.
+        await Assert.That(itemsCompleted).IsGreaterThanOrEqualTo(1);
+
+        Exception? caught = null;
+        try
+        {
+            await executeTask.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            caught = exception;
+        }
+
+        await Assert.That(caught is OperationCanceledException).IsTrue();
+    }
+
     private static async IAsyncEnumerable<int> InfiniteAsyncEnumerable(
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {

--- a/EnumerableAsyncProcessor.UnitTests/V3BinaryCompatibilityTests.cs
+++ b/EnumerableAsyncProcessor.UnitTests/V3BinaryCompatibilityTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EnumerableAsyncProcessor.Builders;
+using EnumerableAsyncProcessor.Extensions;
+
+namespace EnumerableAsyncProcessor.UnitTests;
+
+/// <summary>
+/// TUnit.Engine (the framework running this suite) is itself compiled against
+/// EnumerableAsyncProcessor, and the locally built assembly shadows the version TUnit shipped
+/// with because the assembly identity matches. If a member TUnit.Engine binds to disappears,
+/// test DISCOVERY crashes with MissingMethodException before any test runs. These are the
+/// exact signatures TUnit.Engine references - keep them until TUnit rebuilds against v4.
+/// </summary>
+public class V3BinaryCompatibilityTests
+{
+    [Test]
+    public async Task Members_Bound_By_TUnit_Engine_Exist_With_Exact_Signatures()
+    {
+        // ItemActionAsyncProcessorBuilder<TInput, TOutput>.ProcessInParallel(int)
+        var builderMethod = typeof(ItemActionAsyncProcessorBuilder<,>).GetMethods()
+            .SingleOrDefault(m => m.Name == "ProcessInParallel"
+                                  && m.GetParameters().Length == 1
+                                  && m.GetParameters()[0].ParameterType == typeof(int));
+        await Assert.That(builderMethod).IsNotNull();
+
+        // AsyncEnumerableExtensions.ProcessInParallel<T>(IAsyncEnumerable<T>, CancellationToken)
+        var extensionMethod = typeof(AsyncEnumerableExtensions).GetMethods()
+            .SingleOrDefault(m => m.Name == "ProcessInParallel"
+                                  && m.GetGenericArguments().Length == 1
+                                  && m.GetParameters().Length == 2
+                                  && m.GetParameters()[1].ParameterType == typeof(CancellationToken));
+        await Assert.That(extensionMethod).IsNotNull();
+
+        // TUnit.Engine also binds EnumerableExtensions.SelectAsync / SelectManyAsync and
+        // IAsyncProcessor<T>.GetAwaiter; these exact-signature method groups stop compiling if they drift.
+        Func<IEnumerable<int>, Func<int, Task<int>>, CancellationToken, ItemActionAsyncProcessorBuilder<int, int>> selectAsync =
+            EnumerableExtensions.SelectAsync;
+        Func<IEnumerable<int>, Func<int, IAsyncEnumerable<int>>, CancellationToken, IAsyncEnumerable<int>> selectManyAsync =
+            EnumerableExtensions.SelectManyAsync;
+        await Assert.That(selectAsync).IsNotNull();
+        await Assert.That(selectManyAsync).IsNotNull();
+    }
+}

--- a/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder.cs
+++ b/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder.cs
@@ -58,6 +58,7 @@ public sealed class ActionAsyncProcessorBuilder
     /// Processes items in parallel with bounded concurrency. Binary-compatible with assemblies
     /// compiled against v3 (equivalent to <c>ProcessInParallel(maxConcurrency: n)</c>).
     /// </summary>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public IAsyncProcessor ProcessInParallel(int maxConcurrency)
     {
         return ProcessInParallel((int?)maxConcurrency);

--- a/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder.cs
+++ b/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder.cs
@@ -4,7 +4,7 @@ using EnumerableAsyncProcessor.Extensions;
 
 namespace EnumerableAsyncProcessor.Builders;
 
-public class ActionAsyncProcessorBuilder
+public sealed class ActionAsyncProcessorBuilder
 {
     private readonly int _count;
     private readonly Func<Task> _taskSelector;
@@ -52,6 +52,15 @@ public class ActionAsyncProcessorBuilder
     public IAsyncProcessor ProcessInParallel(int? maxConcurrency = null, bool scheduleOnThreadPool = false)
     {
         return new ParallelAsyncProcessor(_count, _taskSelector, _cancellationTokenSource, maxConcurrency, scheduleOnThreadPool).StartProcessing();
+    }
+
+    /// <summary>
+    /// Processes items in parallel with bounded concurrency. Binary-compatible with assemblies
+    /// compiled against v3 (equivalent to <c>ProcessInParallel(maxConcurrency: n)</c>).
+    /// </summary>
+    public IAsyncProcessor ProcessInParallel(int maxConcurrency)
+    {
+        return ProcessInParallel((int?)maxConcurrency);
     }
     
     public IAsyncProcessor ProcessOneAtATime()

--- a/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder_1.cs
+++ b/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder_1.cs
@@ -58,6 +58,7 @@ public sealed class ActionAsyncProcessorBuilder<TOutput>
     /// Processes items in parallel with bounded concurrency. Binary-compatible with assemblies
     /// compiled against v3 (equivalent to <c>ProcessInParallel(maxConcurrency: n)</c>).
     /// </summary>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public IAsyncProcessor<TOutput> ProcessInParallel(int maxConcurrency)
     {
         return ProcessInParallel((int?)maxConcurrency);

--- a/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder_1.cs
+++ b/EnumerableAsyncProcessor/Builders/ActionAsyncProcessorBuilder_1.cs
@@ -4,7 +4,7 @@ using EnumerableAsyncProcessor.Extensions;
 
 namespace EnumerableAsyncProcessor.Builders;
 
-public class ActionAsyncProcessorBuilder<TOutput>
+public sealed class ActionAsyncProcessorBuilder<TOutput>
 {
     private readonly int _count;
     private readonly Func<Task<TOutput>> _taskSelector;
@@ -52,6 +52,15 @@ public class ActionAsyncProcessorBuilder<TOutput>
     public IAsyncProcessor<TOutput> ProcessInParallel(int? maxConcurrency = null, bool scheduleOnThreadPool = false)
     {
         return new ResultParallelAsyncProcessor<TOutput>(_count, _taskSelector, _cancellationTokenSource, maxConcurrency, scheduleOnThreadPool).StartProcessing();
+    }
+
+    /// <summary>
+    /// Processes items in parallel with bounded concurrency. Binary-compatible with assemblies
+    /// compiled against v3 (equivalent to <c>ProcessInParallel(maxConcurrency: n)</c>).
+    /// </summary>
+    public IAsyncProcessor<TOutput> ProcessInParallel(int maxConcurrency)
+    {
+        return ProcessInParallel((int?)maxConcurrency);
     }
     
     public IAsyncProcessor<TOutput> ProcessOneAtATime()

--- a/EnumerableAsyncProcessor/Builders/AsyncEnumerableActionAsyncProcessorBuilder_1.cs
+++ b/EnumerableAsyncProcessor/Builders/AsyncEnumerableActionAsyncProcessorBuilder_1.cs
@@ -26,7 +26,9 @@ public sealed class AsyncEnumerableActionAsyncProcessorBuilder<TInput>
     {
         _items = items;
         _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _taskSelector = item => taskSelector(item, _cancellationTokenSource.Token);
+        // Capture the token now: the source may be disposed by the time a late item runs the selector.
+        var processorToken = _cancellationTokenSource.Token;
+        _taskSelector = item => taskSelector(item, processorToken);
     }
 
     /// <summary>

--- a/EnumerableAsyncProcessor/Builders/AsyncEnumerableActionAsyncProcessorBuilder_1.cs
+++ b/EnumerableAsyncProcessor/Builders/AsyncEnumerableActionAsyncProcessorBuilder_1.cs
@@ -1,9 +1,9 @@
-using EnumerableAsyncProcessor.Extensions;
+using EnumerableAsyncProcessor.Interfaces;
 using EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable;
 
 namespace EnumerableAsyncProcessor.Builders;
 
-public class AsyncEnumerableActionAsyncProcessorBuilder<TInput>
+public sealed class AsyncEnumerableActionAsyncProcessorBuilder<TInput>
 {
     private readonly IAsyncEnumerable<TInput> _items;
     private readonly Func<TInput, Task> _taskSelector;

--- a/EnumerableAsyncProcessor/Builders/AsyncEnumerableActionAsyncProcessorBuilder_2.cs
+++ b/EnumerableAsyncProcessor/Builders/AsyncEnumerableActionAsyncProcessorBuilder_2.cs
@@ -1,9 +1,9 @@
-using EnumerableAsyncProcessor.Extensions;
+using EnumerableAsyncProcessor.Interfaces;
 using EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors;
 
 namespace EnumerableAsyncProcessor.Builders;
 
-public class AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>
+public sealed class AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>
 {
     private readonly IAsyncEnumerable<TInput> _items;
     private readonly Func<TInput, Task<TOutput>> _taskSelector;

--- a/EnumerableAsyncProcessor/Builders/AsyncEnumerableActionAsyncProcessorBuilder_2.cs
+++ b/EnumerableAsyncProcessor/Builders/AsyncEnumerableActionAsyncProcessorBuilder_2.cs
@@ -26,7 +26,9 @@ public sealed class AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>
     {
         _items = items;
         _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _taskSelector = item => taskSelector(item, _cancellationTokenSource.Token);
+        // Capture the token now: the source may be disposed by the time a late item runs the selector.
+        var processorToken = _cancellationTokenSource.Token;
+        _taskSelector = item => taskSelector(item, processorToken);
     }
 
     /// <summary>

--- a/EnumerableAsyncProcessor/Builders/AsyncEnumerableAsyncProcessorBuilder.cs
+++ b/EnumerableAsyncProcessor/Builders/AsyncEnumerableAsyncProcessorBuilder.cs
@@ -1,6 +1,6 @@
 namespace EnumerableAsyncProcessor.Builders;
 
-public class AsyncEnumerableAsyncProcessorBuilder<TInput>
+public sealed class AsyncEnumerableAsyncProcessorBuilder<TInput>
 {
     private readonly IAsyncEnumerable<TInput> _items;
 

--- a/EnumerableAsyncProcessor/Builders/ExecutionCountAsyncProcessorBuilder.cs
+++ b/EnumerableAsyncProcessor/Builders/ExecutionCountAsyncProcessorBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace EnumerableAsyncProcessor.Builders;
 
-public class ExecutionCountAsyncProcessorBuilder
+public sealed class ExecutionCountAsyncProcessorBuilder
 {
     private readonly int _count;
 

--- a/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_1.cs
+++ b/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_1.cs
@@ -61,6 +61,7 @@ public sealed class ItemActionAsyncProcessorBuilder<TInput>
     /// Processes items in parallel with bounded concurrency. Binary-compatible with assemblies
     /// compiled against v3 (equivalent to <c>ProcessInParallel(maxConcurrency: n)</c>).
     /// </summary>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public IAsyncProcessor ProcessInParallel(int maxConcurrency)
     {
         return ProcessInParallel((int?)maxConcurrency);

--- a/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_1.cs
+++ b/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_1.cs
@@ -4,7 +4,7 @@ using EnumerableAsyncProcessor.Extensions;
 
 namespace EnumerableAsyncProcessor.Builders;
 
-public class ItemActionAsyncProcessorBuilder<TInput>
+public sealed class ItemActionAsyncProcessorBuilder<TInput>
 {
     private readonly IEnumerable<TInput> _items;
     private readonly Func<TInput, Task> _taskSelector;
@@ -55,6 +55,15 @@ public class ItemActionAsyncProcessorBuilder<TInput>
     {
         return new ParallelAsyncProcessor<TInput>(_items, _taskSelector, _cancellationTokenSource, maxConcurrency, scheduleOnThreadPool)
             .StartProcessing();
+    }
+
+    /// <summary>
+    /// Processes items in parallel with bounded concurrency. Binary-compatible with assemblies
+    /// compiled against v3 (equivalent to <c>ProcessInParallel(maxConcurrency: n)</c>).
+    /// </summary>
+    public IAsyncProcessor ProcessInParallel(int maxConcurrency)
+    {
+        return ProcessInParallel((int?)maxConcurrency);
     }
     
     public IAsyncProcessor ProcessOneAtATime()

--- a/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_2.cs
+++ b/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_2.cs
@@ -87,6 +87,7 @@ public sealed class ItemActionAsyncProcessorBuilder<TInput, TOutput>
     /// Processes items in parallel with bounded concurrency. Binary-compatible with assemblies
     /// compiled against v3 (equivalent to <c>ProcessInParallel(maxConcurrency: n)</c>).
     /// </summary>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public IAsyncProcessor<TOutput> ProcessInParallel(int maxConcurrency)
     {
         return ProcessInParallel((int?)maxConcurrency);

--- a/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_2.cs
+++ b/EnumerableAsyncProcessor/Builders/ItemActionAsyncProcessorBuilder_2.cs
@@ -4,7 +4,7 @@ using EnumerableAsyncProcessor.Extensions;
 
 namespace EnumerableAsyncProcessor.Builders;
 
-public class ItemActionAsyncProcessorBuilder<TInput, TOutput>
+public sealed class ItemActionAsyncProcessorBuilder<TInput, TOutput>
 {
     private readonly IEnumerable<TInput> _items;
     private readonly Func<TInput, Task<TOutput>> _taskSelector;
@@ -81,6 +81,15 @@ public class ItemActionAsyncProcessorBuilder<TInput, TOutput>
     public IAsyncProcessor<TOutput> ProcessInParallel(int? maxConcurrency = null, bool scheduleOnThreadPool = false)
     {
         return new ResultParallelAsyncProcessor<TInput, TOutput>(_items, _taskSelector, _cancellationTokenSource, maxConcurrency, scheduleOnThreadPool).StartProcessing();
+    }
+
+    /// <summary>
+    /// Processes items in parallel with bounded concurrency. Binary-compatible with assemblies
+    /// compiled against v3 (equivalent to <c>ProcessInParallel(maxConcurrency: n)</c>).
+    /// </summary>
+    public IAsyncProcessor<TOutput> ProcessInParallel(int maxConcurrency)
+    {
+        return ProcessInParallel((int?)maxConcurrency);
     }
     
     /// <summary>

--- a/EnumerableAsyncProcessor/Builders/ItemAsyncProcessorBuilder.cs
+++ b/EnumerableAsyncProcessor/Builders/ItemAsyncProcessorBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace EnumerableAsyncProcessor.Builders;
 
-public class ItemAsyncProcessorBuilder<TInput>
+public sealed class ItemAsyncProcessorBuilder<TInput>
 {
     private readonly IEnumerable<TInput> _items;
 

--- a/EnumerableAsyncProcessor/EnumerableAsyncProcessor.csproj
+++ b/EnumerableAsyncProcessor/EnumerableAsyncProcessor.csproj
@@ -6,15 +6,23 @@
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <Version>99.99.99</Version>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <IsAotCompatible>true</IsAotCompatible>
         <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017</WarningsAsErrors>
-        <!-- Existing overload families intentionally retain optional parameters. -->
-        <NoWarn>$(NoWarn);RS0026</NoWarn>
+        <!-- RS0026: existing overload families intentionally retain optional parameters.
+             CS1591: not every public member has XML docs yet; don't block the build on it. -->
+        <NoWarn>$(NoWarn);RS0026;CS1591</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Authors>Tom Longhurst</Authors>
+        <Description>Various Enumerable Async Processors - Batch / Parallel / Rate Limited / One at a time</Description>
+        <RepositoryType>git</RepositoryType>
+        <PackageProjectUrl>https://github.com/thomhurst/EnumerableAsyncProcessor</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/thomhurst/EnumerableAsyncProcessor</RepositoryUrl>
+        <PackageTags>async enumerable ienumerable linq array list processor delegate task tasks</PackageTags>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -41,15 +49,5 @@
         <AdditionalFiles Include="PublicAPI.Shipped.txt" />
         <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
     </ItemGroup>
-
-    <PropertyGroup>
-        <Authors>Tom Longhurst</Authors>
-        <Description>Various Enumerable Async Processors - Batch / Parallel / Rate Limited / One at a time</Description>
-        <RepositoryType>git</RepositoryType>
-        <PackageProjectUrl>https://github.com/thomhurst/EnumerableAsyncProcessor</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/thomhurst/EnumerableAsyncProcessor</RepositoryUrl>
-        <PackageTags>async enumerable ienumerable linq array list processor delegate task tasks</PackageTags>
-    </PropertyGroup>
-
 
 </Project>

--- a/EnumerableAsyncProcessor/Extensions/AsyncEnumerableExtensions.cs
+++ b/EnumerableAsyncProcessor/Extensions/AsyncEnumerableExtensions.cs
@@ -151,33 +151,11 @@ public static class AsyncEnumerableExtensions
     }
     
     /// <summary>
-    /// Process items in parallel and return all results as IEnumerable when awaited.
+    /// Collects every item from the source into a list. This overload has no work to parallelize;
+    /// it is kept for binary compatibility with assemblies compiled against v3 (notably TUnit).
     /// </summary>
     public static async Task<IEnumerable<T>> ProcessInParallel<T>(
         this IAsyncEnumerable<T> items,
-        CancellationToken cancellationToken = default)
-    {
-        return await items.ProcessInParallel(null, false, cancellationToken).ConfigureAwait(false);
-    }
-    
-    /// <summary>
-    /// Process items in parallel with specified concurrency and return all results as IEnumerable when awaited.
-    /// </summary>
-    public static async Task<IEnumerable<T>> ProcessInParallel<T>(
-        this IAsyncEnumerable<T> items,
-        int maxConcurrency,
-        CancellationToken cancellationToken = default)
-    {
-        return await items.ProcessInParallel((int?)maxConcurrency, false, cancellationToken).ConfigureAwait(false);
-    }
-    
-    /// <summary>
-    /// Process items in parallel with optional concurrency and thread pool scheduling, return all results as IEnumerable when awaited.
-    /// </summary>
-    public static async Task<IEnumerable<T>> ProcessInParallel<T>(
-        this IAsyncEnumerable<T> items,
-        int? maxConcurrency,
-        bool scheduleOnThreadPool,
         CancellationToken cancellationToken = default)
     {
         var results = new List<T>();
@@ -189,7 +167,7 @@ public static class AsyncEnumerableExtensions
 
         return results;
     }
-    
+
     /// <summary>
     /// Process items in parallel with transformation and return all results as IEnumerable when awaited.
     /// </summary>
@@ -224,12 +202,16 @@ public static class AsyncEnumerableExtensions
         CancellationToken cancellationToken = default)
     {
         var results = new List<TOutput>();
-        
+
         if (maxConcurrency.HasValue)
         {
+            Func<T, Task<TOutput>> effectiveSelector = scheduleOnThreadPool
+                ? item => Task.Run(() => taskSelector(item), cancellationToken)
+                : taskSelector;
+
             await foreach (var result in AsyncEnumerableWorkerPool.ProcessResultsAsync(
                                items,
-                               taskSelector,
+                               effectiveSelector,
                                maxConcurrency.Value,
                                cancellationToken).ConfigureAwait(false))
             {

--- a/EnumerableAsyncProcessor/Extensions/AsyncEnumerableExtensions.cs
+++ b/EnumerableAsyncProcessor/Extensions/AsyncEnumerableExtensions.cs
@@ -154,6 +154,8 @@ public static class AsyncEnumerableExtensions
     /// Collects every item from the source into a list. This overload has no work to parallelize;
     /// it is kept for binary compatibility with assemblies compiled against v3 (notably TUnit).
     /// </summary>
+    [Obsolete("This overload only collects the stream and parallelizes nothing. Pass a selector, or enumerate the stream directly. It exists for binary compatibility with assemblies compiled against v3.")]
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public static async Task<IEnumerable<T>> ProcessInParallel<T>(
         this IAsyncEnumerable<T> items,
         CancellationToken cancellationToken = default)

--- a/EnumerableAsyncProcessor/Extensions/EnumerableExtensions.cs
+++ b/EnumerableAsyncProcessor/Extensions/EnumerableExtensions.cs
@@ -138,18 +138,6 @@ public static class EnumerableExtensions
         }
     }
     
-    private static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(
-        this IEnumerable<T> items,
-        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
-    {
-        foreach (var item in items)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            yield return item;
-        }
-        await Task.CompletedTask; // Suppress CS1998 warning
-    }
-
     internal static async IAsyncEnumerable<T> ToIAsyncEnumerable<T>(this IEnumerable<Task<T>> tasks, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
 #if NET9_0_OR_GREATER

--- a/EnumerableAsyncProcessor/Interfaces/IAsyncEnumerableProcessor.cs
+++ b/EnumerableAsyncProcessor/Interfaces/IAsyncEnumerableProcessor.cs
@@ -1,11 +1,27 @@
-namespace EnumerableAsyncProcessor.Extensions;
+namespace EnumerableAsyncProcessor.Interfaces;
 
-public interface IAsyncEnumerableProcessor
+/// <summary>
+/// A single-use processor for an <see cref="IAsyncEnumerable{T}"/> source that performs
+/// an operation per item without returning results.
+/// </summary>
+public interface IAsyncEnumerableProcessor : IAsyncDisposable, IDisposable
 {
+    /// <summary>
+    /// Processes the source. The processor is single-use; it disposes its internal
+    /// resources when processing completes.
+    /// </summary>
     Task ExecuteAsync();
 }
 
-public interface IAsyncEnumerableProcessor<TOutput>
+/// <summary>
+/// A single-use processor for an <see cref="IAsyncEnumerable{T}"/> source that streams
+/// one result per item.
+/// </summary>
+public interface IAsyncEnumerableProcessor<out TOutput> : IAsyncDisposable, IDisposable
 {
+    /// <summary>
+    /// Processes the source, streaming results as they become available. The processor is
+    /// single-use; it disposes its internal resources when enumeration finishes.
+    /// </summary>
     IAsyncEnumerable<TOutput> ExecuteAsync();
 }

--- a/EnumerableAsyncProcessor/ProcessorLifecycle.cs
+++ b/EnumerableAsyncProcessor/ProcessorLifecycle.cs
@@ -8,7 +8,7 @@ namespace EnumerableAsyncProcessor;
 /// </summary>
 internal sealed class ProcessorLifecycle
 {
-    private static readonly TimeSpan DisposalTimeout = TimeSpan.FromSeconds(30);
+    internal static readonly TimeSpan DisposalTimeout = TimeSpan.FromSeconds(30);
 
     private readonly CancellationTokenSource _cancellationTokenSource;
     private readonly Action _trySetCanceledAll;

--- a/EnumerableAsyncProcessor/PublicAPI.Shipped.txt
+++ b/EnumerableAsyncProcessor/PublicAPI.Shipped.txt
@@ -1,24 +1,16 @@
 #nullable enable
-abstract EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessorBase.EnumerableTaskCompletionSources.get -> System.Collections.Generic.IReadOnlyList<System.Threading.Tasks.TaskCompletionSource!>!
-abstract EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessorBase<TOutput>.EnumerableTaskCompletionSources.get -> System.Collections.Generic.IReadOnlyList<System.Threading.Tasks.TaskCompletionSource<TOutput>!>!
-EnumerableAsyncProcessor.ActionTaskWrapper
-EnumerableAsyncProcessor.ActionTaskWrapper.ActionTaskWrapper() -> void
-EnumerableAsyncProcessor.ActionTaskWrapper.ActionTaskWrapper(System.Func<System.Threading.Tasks.Task!>! taskFactory, System.Threading.Tasks.TaskCompletionSource! taskCompletionSource) -> void
-EnumerableAsyncProcessor.ActionTaskWrapper.Process(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-EnumerableAsyncProcessor.ActionTaskWrapper<TOutput>
-EnumerableAsyncProcessor.ActionTaskWrapper<TOutput>.ActionTaskWrapper() -> void
-EnumerableAsyncProcessor.ActionTaskWrapper<TOutput>.ActionTaskWrapper(System.Func<System.Threading.Tasks.Task<TOutput>!>! taskFactory, System.Threading.Tasks.TaskCompletionSource<TOutput>! taskCompletionSource) -> void
-EnumerableAsyncProcessor.ActionTaskWrapper<TOutput>.Process(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder
 EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder.ActionAsyncProcessorBuilder(int count, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! taskSelector, System.Threading.CancellationToken cancellationToken) -> void
 EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder.ActionAsyncProcessorBuilder(int count, System.Func<System.Threading.Tasks.Task!>! taskSelector, System.Threading.CancellationToken cancellationToken) -> void
 EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder.ProcessInBatches(int batchSize) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor!
+EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder.ProcessInParallel(int maxConcurrency) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor!
 EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder.ProcessInParallel(int maxConcurrency, System.TimeSpan timeSpan) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor!
 EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder.ProcessInParallel(int permitsPerWindow, System.TimeSpan window, int maxConcurrency) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor!
 EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder.ProcessInParallel(int? maxConcurrency = null, bool scheduleOnThreadPool = false) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor!
 EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder.ProcessOneAtATime() -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor!
 EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder<TOutput>
 EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder<TOutput>.ProcessInBatches(int batchSize) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor<TOutput>!
+EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder<TOutput>.ProcessInParallel(int maxConcurrency) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor<TOutput>!
 EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder<TOutput>.ProcessInParallel(int maxConcurrency, System.TimeSpan timeSpan) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor<TOutput>!
 EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder<TOutput>.ProcessInParallel(int permitsPerWindow, System.TimeSpan window, int maxConcurrency) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor<TOutput>!
 EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder<TOutput>.ProcessInParallel(int? maxConcurrency = null, bool scheduleOnThreadPool = false) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor<TOutput>!
@@ -26,15 +18,15 @@ EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder<TOutput>.ProcessOn
 EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>
 EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>.AsyncEnumerableActionAsyncProcessorBuilder(System.Collections.Generic.IAsyncEnumerable<TInput>! items, System.Func<TInput, System.Threading.CancellationToken, System.Threading.Tasks.Task<TOutput>!>! taskSelector, System.Threading.CancellationToken cancellationToken) -> void
 EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>.AsyncEnumerableActionAsyncProcessorBuilder(System.Collections.Generic.IAsyncEnumerable<TInput>! items, System.Func<TInput, System.Threading.Tasks.Task<TOutput>!>! taskSelector, System.Threading.CancellationToken cancellationToken) -> void
-EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>.ProcessInBatches(int batchSize) -> EnumerableAsyncProcessor.Extensions.IAsyncEnumerableProcessor<TOutput>!
-EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>.ProcessInParallel(int? maxConcurrency = null, bool scheduleOnThreadPool = false) -> EnumerableAsyncProcessor.Extensions.IAsyncEnumerableProcessor<TOutput>!
-EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>.ProcessOneAtATime() -> EnumerableAsyncProcessor.Extensions.IAsyncEnumerableProcessor<TOutput>!
+EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>.ProcessInBatches(int batchSize) -> EnumerableAsyncProcessor.Interfaces.IAsyncEnumerableProcessor<TOutput>!
+EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>.ProcessInParallel(int? maxConcurrency = null, bool scheduleOnThreadPool = false) -> EnumerableAsyncProcessor.Interfaces.IAsyncEnumerableProcessor<TOutput>!
+EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput, TOutput>.ProcessOneAtATime() -> EnumerableAsyncProcessor.Interfaces.IAsyncEnumerableProcessor<TOutput>!
 EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput>
 EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput>.AsyncEnumerableActionAsyncProcessorBuilder(System.Collections.Generic.IAsyncEnumerable<TInput>! items, System.Func<TInput, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! taskSelector, System.Threading.CancellationToken cancellationToken) -> void
 EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput>.AsyncEnumerableActionAsyncProcessorBuilder(System.Collections.Generic.IAsyncEnumerable<TInput>! items, System.Func<TInput, System.Threading.Tasks.Task!>! taskSelector, System.Threading.CancellationToken cancellationToken) -> void
-EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput>.ProcessInBatches(int batchSize) -> EnumerableAsyncProcessor.Extensions.IAsyncEnumerableProcessor!
-EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput>.ProcessInParallel(int? maxConcurrency = null, bool scheduleOnThreadPool = false) -> EnumerableAsyncProcessor.Extensions.IAsyncEnumerableProcessor!
-EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput>.ProcessOneAtATime() -> EnumerableAsyncProcessor.Extensions.IAsyncEnumerableProcessor!
+EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput>.ProcessInBatches(int batchSize) -> EnumerableAsyncProcessor.Interfaces.IAsyncEnumerableProcessor!
+EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput>.ProcessInParallel(int? maxConcurrency = null, bool scheduleOnThreadPool = false) -> EnumerableAsyncProcessor.Interfaces.IAsyncEnumerableProcessor!
+EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput>.ProcessOneAtATime() -> EnumerableAsyncProcessor.Interfaces.IAsyncEnumerableProcessor!
 EnumerableAsyncProcessor.Builders.AsyncEnumerableAsyncProcessorBuilder<TInput>
 EnumerableAsyncProcessor.Builders.AsyncEnumerableAsyncProcessorBuilder<TInput>.ForEachAsync(System.Func<TInput, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! taskSelector) -> EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput>!
 EnumerableAsyncProcessor.Builders.AsyncEnumerableAsyncProcessorBuilder<TInput>.ForEachAsync(System.Func<TInput, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! taskSelector, System.Threading.CancellationToken cancellationToken) -> EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<TInput>!
@@ -56,6 +48,7 @@ EnumerableAsyncProcessor.Builders.ExecutionCountAsyncProcessorBuilder.SelectAsyn
 EnumerableAsyncProcessor.Builders.ExecutionCountAsyncProcessorBuilder.SelectAsync<TOutput>(System.Func<System.Threading.Tasks.Task<TOutput>!>! taskSelector, System.Threading.CancellationToken cancellationToken) -> EnumerableAsyncProcessor.Builders.ActionAsyncProcessorBuilder<TOutput>!
 EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput, TOutput>
 EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput, TOutput>.ProcessInBatches(int batchSize) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor<TOutput>!
+EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput, TOutput>.ProcessInParallel(int maxConcurrency) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor<TOutput>!
 EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput, TOutput>.ProcessInParallel(int maxConcurrency, System.TimeSpan timeSpan) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor<TOutput>!
 EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput, TOutput>.ProcessInParallel(int permitsPerWindow, System.TimeSpan window, int maxConcurrency) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor<TOutput>!
 EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput, TOutput>.ProcessInParallel(int? maxConcurrency = null, bool scheduleOnThreadPool = false) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor<TOutput>!
@@ -64,6 +57,7 @@ EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput>
 EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput>.ItemActionAsyncProcessorBuilder(System.Collections.Generic.IEnumerable<TInput>! items, System.Func<TInput, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! taskSelector, System.Threading.CancellationToken cancellationToken) -> void
 EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput>.ItemActionAsyncProcessorBuilder(System.Collections.Generic.IEnumerable<TInput>! items, System.Func<TInput, System.Threading.Tasks.Task!>! taskSelector, System.Threading.CancellationToken cancellationToken) -> void
 EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput>.ProcessInBatches(int batchSize) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor!
+EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput>.ProcessInParallel(int maxConcurrency) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor!
 EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput>.ProcessInParallel(int maxConcurrency, System.TimeSpan timeSpan) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor!
 EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput>.ProcessInParallel(int permitsPerWindow, System.TimeSpan window, int maxConcurrency) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor!
 EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput>.ProcessInParallel(int? maxConcurrency = null, bool scheduleOnThreadPool = false) -> EnumerableAsyncProcessor.Interfaces.IAsyncProcessor!
@@ -79,11 +73,11 @@ EnumerableAsyncProcessor.Builders.ItemAsyncProcessorBuilder<TInput>.SelectAsync<
 EnumerableAsyncProcessor.Builders.ItemAsyncProcessorBuilder<TInput>.SelectAsync<TOutput>(System.Func<TInput, System.Threading.Tasks.Task<TOutput>!>! taskSelector, System.Threading.CancellationToken cancellationToken) -> EnumerableAsyncProcessor.Builders.ItemActionAsyncProcessorBuilder<TInput, TOutput>!
 EnumerableAsyncProcessor.Extensions.AsyncEnumerableExtensions
 EnumerableAsyncProcessor.Extensions.EnumerableExtensions
-EnumerableAsyncProcessor.Extensions.IAsyncEnumerableProcessor
-EnumerableAsyncProcessor.Extensions.IAsyncEnumerableProcessor.ExecuteAsync() -> System.Threading.Tasks.Task!
-EnumerableAsyncProcessor.Extensions.IAsyncEnumerableProcessor<TOutput>
-EnumerableAsyncProcessor.Extensions.IAsyncEnumerableProcessor<TOutput>.ExecuteAsync() -> System.Collections.Generic.IAsyncEnumerable<TOutput>!
 EnumerableAsyncProcessor.Extensions.ParallelExtensions
+EnumerableAsyncProcessor.Interfaces.IAsyncEnumerableProcessor
+EnumerableAsyncProcessor.Interfaces.IAsyncEnumerableProcessor.ExecuteAsync() -> System.Threading.Tasks.Task!
+EnumerableAsyncProcessor.Interfaces.IAsyncEnumerableProcessor<TOutput>
+EnumerableAsyncProcessor.Interfaces.IAsyncEnumerableProcessor<TOutput>.ExecuteAsync() -> System.Collections.Generic.IAsyncEnumerable<TOutput>!
 EnumerableAsyncProcessor.Interfaces.IAsyncProcessor
 EnumerableAsyncProcessor.Interfaces.IAsyncProcessor.CancelAll() -> void
 EnumerableAsyncProcessor.Interfaces.IAsyncProcessor.GetAwaiter() -> System.Runtime.CompilerServices.TaskAwaiter
@@ -95,20 +89,9 @@ EnumerableAsyncProcessor.Interfaces.IAsyncProcessor<TOutput>.GetAwaiter() -> Sys
 EnumerableAsyncProcessor.Interfaces.IAsyncProcessor<TOutput>.GetEnumerableTasks() -> System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task<TOutput>!>!
 EnumerableAsyncProcessor.Interfaces.IAsyncProcessor<TOutput>.GetResultsAsync() -> System.Threading.Tasks.Task<TOutput[]!>!
 EnumerableAsyncProcessor.Interfaces.IAsyncProcessor<TOutput>.GetResultsAsyncEnumerable() -> System.Collections.Generic.IAsyncEnumerable<TOutput>!
-EnumerableAsyncProcessor.ItemTaskWrapper<TInput, TOutput>
-EnumerableAsyncProcessor.ItemTaskWrapper<TInput, TOutput>.ItemTaskWrapper() -> void
-EnumerableAsyncProcessor.ItemTaskWrapper<TInput, TOutput>.ItemTaskWrapper(TInput input, System.Func<TInput, System.Threading.Tasks.Task<TOutput>!>! taskFactory, System.Threading.Tasks.TaskCompletionSource<TOutput>! taskCompletionSource) -> void
-EnumerableAsyncProcessor.ItemTaskWrapper<TInput, TOutput>.Process(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-EnumerableAsyncProcessor.ItemTaskWrapper<TInput>
-EnumerableAsyncProcessor.ItemTaskWrapper<TInput>.ItemTaskWrapper() -> void
-EnumerableAsyncProcessor.ItemTaskWrapper<TInput>.ItemTaskWrapper(TInput input, System.Func<TInput, System.Threading.Tasks.Task!>! taskFactory, System.Threading.Tasks.TaskCompletionSource! taskCompletionSource) -> void
-EnumerableAsyncProcessor.ItemTaskWrapper<TInput>.Process(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessor
-EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessor.AbstractAsyncProcessor(int count, System.Func<System.Threading.Tasks.Task!>! taskSelector, System.Threading.CancellationTokenSource! cancellationTokenSource) -> void
 EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessor<TInput>
-EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessor<TInput>.AbstractAsyncProcessor(System.Collections.Generic.IEnumerable<TInput>! items, System.Func<TInput, System.Threading.Tasks.Task!>! taskSelector, System.Threading.CancellationTokenSource! cancellationTokenSource) -> void
 EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessorBase
-EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessorBase.AbstractAsyncProcessorBase(System.Threading.CancellationTokenSource! cancellationTokenSource) -> void
 EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessorBase.CancelAll() -> void
 EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessorBase.Dispose() -> void
 EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessorBase.DisposeAsync() -> System.Threading.Tasks.ValueTask
@@ -116,16 +99,28 @@ EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessorBase.
 EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessorBase.GetEnumerableTasks() -> System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task!>!
 EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessorBase.WaitAsync() -> System.Threading.Tasks.Task!
 EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.AsyncEnumerableBatchProcessor<TInput>
+EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.AsyncEnumerableBatchProcessor<TInput>.Dispose() -> void
+EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.AsyncEnumerableBatchProcessor<TInput>.DisposeAsync() -> System.Threading.Tasks.ValueTask
 EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.AsyncEnumerableBatchProcessor<TInput>.ExecuteAsync() -> System.Threading.Tasks.Task!
 EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.AsyncEnumerableOneAtATimeProcessor<TInput>
+EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.AsyncEnumerableOneAtATimeProcessor<TInput>.Dispose() -> void
+EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.AsyncEnumerableOneAtATimeProcessor<TInput>.DisposeAsync() -> System.Threading.Tasks.ValueTask
 EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.AsyncEnumerableOneAtATimeProcessor<TInput>.ExecuteAsync() -> System.Threading.Tasks.Task!
 EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.AsyncEnumerableParallelProcessor<TInput>
+EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.AsyncEnumerableParallelProcessor<TInput>.Dispose() -> void
+EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.AsyncEnumerableParallelProcessor<TInput>.DisposeAsync() -> System.Threading.Tasks.ValueTask
 EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.AsyncEnumerableParallelProcessor<TInput>.ExecuteAsync() -> System.Threading.Tasks.Task!
 EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors.ResultAsyncEnumerableBatchProcessor<TInput, TOutput>
+EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors.ResultAsyncEnumerableBatchProcessor<TInput, TOutput>.Dispose() -> void
+EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors.ResultAsyncEnumerableBatchProcessor<TInput, TOutput>.DisposeAsync() -> System.Threading.Tasks.ValueTask
 EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors.ResultAsyncEnumerableBatchProcessor<TInput, TOutput>.ExecuteAsync() -> System.Collections.Generic.IAsyncEnumerable<TOutput>!
 EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors.ResultAsyncEnumerableOneAtATimeProcessor<TInput, TOutput>
+EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors.ResultAsyncEnumerableOneAtATimeProcessor<TInput, TOutput>.Dispose() -> void
+EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors.ResultAsyncEnumerableOneAtATimeProcessor<TInput, TOutput>.DisposeAsync() -> System.Threading.Tasks.ValueTask
 EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors.ResultAsyncEnumerableOneAtATimeProcessor<TInput, TOutput>.ExecuteAsync() -> System.Collections.Generic.IAsyncEnumerable<TOutput>!
 EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors.ResultAsyncEnumerableParallelProcessor<TInput, TOutput>
+EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors.ResultAsyncEnumerableParallelProcessor<TInput, TOutput>.Dispose() -> void
+EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors.ResultAsyncEnumerableParallelProcessor<TInput, TOutput>.DisposeAsync() -> System.Threading.Tasks.ValueTask
 EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors.ResultAsyncEnumerableParallelProcessor<TInput, TOutput>.ExecuteAsync() -> System.Collections.Generic.IAsyncEnumerable<TOutput>!
 EnumerableAsyncProcessor.RunnableProcessors.BatchAsyncProcessor
 EnumerableAsyncProcessor.RunnableProcessors.BatchAsyncProcessor<TInput>
@@ -134,9 +129,7 @@ EnumerableAsyncProcessor.RunnableProcessors.OneAtATimeAsyncProcessor<TInput>
 EnumerableAsyncProcessor.RunnableProcessors.ParallelAsyncProcessor
 EnumerableAsyncProcessor.RunnableProcessors.ParallelAsyncProcessor<TInput>
 EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessor<TInput, TOutput>
-EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessor<TInput, TOutput>.ResultAbstractAsyncProcessor(System.Collections.Generic.IEnumerable<TInput>! items, System.Func<TInput, System.Threading.Tasks.Task<TOutput>!>! taskSelector, System.Threading.CancellationTokenSource! cancellationTokenSource) -> void
 EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessor<TOutput>
-EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessor<TOutput>.ResultAbstractAsyncProcessor(int count, System.Func<System.Threading.Tasks.Task<TOutput>!>! taskSelector, System.Threading.CancellationTokenSource! cancellationTokenSource) -> void
 EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessorBase<TOutput>
 EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessorBase<TOutput>.CancelAll() -> void
 EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessorBase<TOutput>.Dispose() -> void
@@ -145,7 +138,6 @@ EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbst
 EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessorBase<TOutput>.GetEnumerableTasks() -> System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task<TOutput>!>!
 EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessorBase<TOutput>.GetResultsAsync() -> System.Threading.Tasks.Task<TOutput[]!>!
 EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessorBase<TOutput>.GetResultsAsyncEnumerable() -> System.Collections.Generic.IAsyncEnumerable<TOutput>!
-EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessorBase<TOutput>.ResultAbstractAsyncProcessorBase(System.Threading.CancellationTokenSource! cancellationTokenSource) -> void
 EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.ResultBatchAsyncProcessor<TInput, TOutput>
 EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.ResultBatchAsyncProcessor<TOutput>
 EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.ResultOneAtATimeAsyncProcessor<TInput, TOutput>
@@ -156,35 +148,13 @@ EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.ResultTimedRateLimi
 EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.ResultTimedRateLimitedParallelAsyncProcessor<TOutput>
 EnumerableAsyncProcessor.RunnableProcessors.TimedRateLimitedParallelAsyncProcessor
 EnumerableAsyncProcessor.RunnableProcessors.TimedRateLimitedParallelAsyncProcessor<TInput>
-override EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessor.EnumerableTaskCompletionSources.get -> System.Collections.Generic.IReadOnlyList<System.Threading.Tasks.TaskCompletionSource!>!
-override EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessor<TInput>.EnumerableTaskCompletionSources.get -> System.Collections.Generic.IReadOnlyList<System.Threading.Tasks.TaskCompletionSource!>!
-override EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessor<TInput, TOutput>.EnumerableTaskCompletionSources.get -> System.Collections.Generic.IReadOnlyList<System.Threading.Tasks.TaskCompletionSource<TOutput>!>!
-override EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessor<TOutput>.EnumerableTaskCompletionSources.get -> System.Collections.Generic.IReadOnlyList<System.Threading.Tasks.TaskCompletionSource<TOutput>!>!
-readonly EnumerableAsyncProcessor.ActionTaskWrapper.TaskCompletionSource -> System.Threading.Tasks.TaskCompletionSource!
-readonly EnumerableAsyncProcessor.ActionTaskWrapper.TaskFactory -> System.Func<System.Threading.Tasks.Task!>!
-readonly EnumerableAsyncProcessor.ActionTaskWrapper<TOutput>.TaskCompletionSource -> System.Threading.Tasks.TaskCompletionSource<TOutput>!
-readonly EnumerableAsyncProcessor.ActionTaskWrapper<TOutput>.TaskFactory -> System.Func<System.Threading.Tasks.Task<TOutput>!>!
-readonly EnumerableAsyncProcessor.ItemTaskWrapper<TInput, TOutput>.Input -> TInput
-readonly EnumerableAsyncProcessor.ItemTaskWrapper<TInput, TOutput>.TaskCompletionSource -> System.Threading.Tasks.TaskCompletionSource<TOutput>!
-readonly EnumerableAsyncProcessor.ItemTaskWrapper<TInput, TOutput>.TaskFactory -> System.Func<TInput, System.Threading.Tasks.Task<TOutput>!>!
-readonly EnumerableAsyncProcessor.ItemTaskWrapper<TInput>.Input -> TInput
-readonly EnumerableAsyncProcessor.ItemTaskWrapper<TInput>.TaskCompletionSource -> System.Threading.Tasks.TaskCompletionSource!
-readonly EnumerableAsyncProcessor.ItemTaskWrapper<TInput>.TaskFactory -> System.Func<TInput, System.Threading.Tasks.Task!>!
-readonly EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessor.TaskWrappers -> EnumerableAsyncProcessor.ActionTaskWrapper[]!
-readonly EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessor<TInput>.TaskWrappers -> EnumerableAsyncProcessor.ItemTaskWrapper<TInput>[]!
-readonly EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessorBase.CancellationToken -> System.Threading.CancellationToken
-readonly EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessor<TInput, TOutput>.TaskWrappers -> EnumerableAsyncProcessor.ItemTaskWrapper<TInput, TOutput>[]!
-readonly EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessor<TOutput>.TaskWrappers -> EnumerableAsyncProcessor.ActionTaskWrapper<TOutput>[]!
-readonly EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessorBase<TOutput>.CancellationToken -> System.Threading.CancellationToken
 static EnumerableAsyncProcessor.Builders.AsyncProcessorBuilder.WithExecutionCount(int count) -> EnumerableAsyncProcessor.Builders.ExecutionCountAsyncProcessorBuilder!
 static EnumerableAsyncProcessor.Builders.AsyncProcessorBuilder.WithItems<T>(System.Collections.Generic.IEnumerable<T>! items) -> EnumerableAsyncProcessor.Builders.ItemAsyncProcessorBuilder<T>!
 static EnumerableAsyncProcessor.Extensions.AsyncEnumerableExtensions.ForEachAsync<T>(this System.Collections.Generic.IAsyncEnumerable<T>! items, System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! taskSelector, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<T>!
 static EnumerableAsyncProcessor.Extensions.AsyncEnumerableExtensions.ForEachAsync<T>(this System.Collections.Generic.IAsyncEnumerable<T>! items, System.Func<T, System.Threading.Tasks.Task!>! taskSelector, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<T>!
+static EnumerableAsyncProcessor.Extensions.AsyncEnumerableExtensions.ProcessInParallel<T, TOutput>(this System.Collections.Generic.IAsyncEnumerable<T>! items, System.Func<T, System.Threading.Tasks.Task<TOutput>!>! taskSelector, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<TOutput>!>!
 static EnumerableAsyncProcessor.Extensions.AsyncEnumerableExtensions.ProcessInParallel<T, TOutput>(this System.Collections.Generic.IAsyncEnumerable<T>! items, System.Func<T, System.Threading.Tasks.Task<TOutput>!>! taskSelector, int maxConcurrency, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<TOutput>!>!
 static EnumerableAsyncProcessor.Extensions.AsyncEnumerableExtensions.ProcessInParallel<T, TOutput>(this System.Collections.Generic.IAsyncEnumerable<T>! items, System.Func<T, System.Threading.Tasks.Task<TOutput>!>! taskSelector, int? maxConcurrency, bool scheduleOnThreadPool, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<TOutput>!>!
-static EnumerableAsyncProcessor.Extensions.AsyncEnumerableExtensions.ProcessInParallel<T, TOutput>(this System.Collections.Generic.IAsyncEnumerable<T>! items, System.Func<T, System.Threading.Tasks.Task<TOutput>!>! taskSelector, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<TOutput>!>!
-static EnumerableAsyncProcessor.Extensions.AsyncEnumerableExtensions.ProcessInParallel<T>(this System.Collections.Generic.IAsyncEnumerable<T>! items, int maxConcurrency, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<T>!>!
-static EnumerableAsyncProcessor.Extensions.AsyncEnumerableExtensions.ProcessInParallel<T>(this System.Collections.Generic.IAsyncEnumerable<T>! items, int? maxConcurrency, bool scheduleOnThreadPool, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<T>!>!
 static EnumerableAsyncProcessor.Extensions.AsyncEnumerableExtensions.ProcessInParallel<T>(this System.Collections.Generic.IAsyncEnumerable<T>! items, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<T>!>!
 static EnumerableAsyncProcessor.Extensions.AsyncEnumerableExtensions.SelectAsync<T, TOutput>(this System.Collections.Generic.IAsyncEnumerable<T>! items, System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task<TOutput>!>! taskSelector, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<T, TOutput>!
 static EnumerableAsyncProcessor.Extensions.AsyncEnumerableExtensions.SelectAsync<T, TOutput>(this System.Collections.Generic.IAsyncEnumerable<T>! items, System.Func<T, System.Threading.Tasks.Task<TOutput>!>! taskSelector, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> EnumerableAsyncProcessor.Builders.AsyncEnumerableActionAsyncProcessorBuilder<T, TOutput>!
@@ -210,5 +180,3 @@ static EnumerableAsyncProcessor.Extensions.ParallelExtensions.InParallelAsync<TS
 static EnumerableAsyncProcessor.Extensions.ParallelExtensions.InParallelAsync<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int levelOfParallelism, System.Action<TSource>! taskSelector, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 static EnumerableAsyncProcessor.Extensions.ParallelExtensions.InParallelAsync<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int levelOfParallelism, System.Func<TSource, System.Threading.Tasks.Task!>! taskSelector) -> System.Threading.Tasks.Task!
 static EnumerableAsyncProcessor.Extensions.ParallelExtensions.InParallelAsync<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int levelOfParallelism, System.Func<TSource, System.Threading.Tasks.Task!>! taskSelector, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-virtual EnumerableAsyncProcessor.RunnableProcessors.Abstract.AbstractAsyncProcessorBase.DisposeAsyncCore() -> System.Threading.Tasks.ValueTask
-virtual EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract.ResultAbstractAsyncProcessorBase<TOutput>.DisposeAsyncCore() -> System.Threading.Tasks.ValueTask

--- a/EnumerableAsyncProcessor/RunnableProcessors/Abstract/AbstractAsyncProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/Abstract/AbstractAsyncProcessor.cs
@@ -4,13 +4,13 @@ namespace EnumerableAsyncProcessor.RunnableProcessors.Abstract;
 
 public abstract class AbstractAsyncProcessor : AbstractAsyncProcessorBase
 {
-    protected readonly ActionTaskWrapper[] TaskWrappers;
+    private protected readonly ActionTaskWrapper[] TaskWrappers;
 
     private readonly TaskCompletionSource[] _taskCompletionSources;
 
-    protected override IReadOnlyList<TaskCompletionSource> EnumerableTaskCompletionSources => _taskCompletionSources;
+    private protected override IReadOnlyList<TaskCompletionSource> EnumerableTaskCompletionSources => _taskCompletionSources;
 
-    protected AbstractAsyncProcessor(int count, Func<Task> taskSelector, CancellationTokenSource cancellationTokenSource) : base(cancellationTokenSource)
+    private protected AbstractAsyncProcessor(int count, Func<Task> taskSelector, CancellationTokenSource cancellationTokenSource) : base(cancellationTokenSource)
     {
         ValidationHelper.ThrowIfNegative(count);
         ValidationHelper.ThrowIfNull(taskSelector);

--- a/EnumerableAsyncProcessor/RunnableProcessors/Abstract/AbstractAsyncProcessorBase.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/Abstract/AbstractAsyncProcessorBase.cs
@@ -5,15 +5,15 @@ namespace EnumerableAsyncProcessor.RunnableProcessors.Abstract;
 
 public abstract class AbstractAsyncProcessorBase : IAsyncProcessor, IAsyncDisposable, IDisposable
 {
-    protected abstract IReadOnlyList<TaskCompletionSource> EnumerableTaskCompletionSources { get; }
-    protected readonly CancellationToken CancellationToken;
+    private protected abstract IReadOnlyList<TaskCompletionSource> EnumerableTaskCompletionSources { get; }
+    private protected readonly CancellationToken CancellationToken;
 
     private readonly ProcessorLifecycle _lifecycle;
     private Task? _overallTask;
 
     private Task OverallTask => _overallTask ??= Task.WhenAll(GetEnumerableTasks());
 
-    protected AbstractAsyncProcessorBase(CancellationTokenSource cancellationTokenSource)
+    private protected AbstractAsyncProcessorBase(CancellationTokenSource cancellationTokenSource)
     {
         _lifecycle = new ProcessorLifecycle(cancellationTokenSource, TrySetCanceledAll, TrySetExceptionAll);
         CancellationToken = _lifecycle.Token;
@@ -69,7 +69,7 @@ public abstract class AbstractAsyncProcessorBase : IAsyncProcessor, IAsyncDispos
         GC.SuppressFinalize(this);
     }
 
-    protected virtual ValueTask DisposeAsyncCore()
+    private protected virtual ValueTask DisposeAsyncCore()
     {
         return ValueTask.CompletedTask;
     }

--- a/EnumerableAsyncProcessor/RunnableProcessors/Abstract/AbstractAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/Abstract/AbstractAsyncProcessor_1.cs
@@ -4,13 +4,13 @@ namespace EnumerableAsyncProcessor.RunnableProcessors.Abstract;
 
 public abstract class AbstractAsyncProcessor<TInput> : AbstractAsyncProcessorBase
 {
-    protected readonly ItemTaskWrapper<TInput>[] TaskWrappers;
+    private protected readonly ItemTaskWrapper<TInput>[] TaskWrappers;
 
     private readonly TaskCompletionSource[] _taskCompletionSources;
 
-    protected override IReadOnlyList<TaskCompletionSource> EnumerableTaskCompletionSources => _taskCompletionSources;
+    private protected override IReadOnlyList<TaskCompletionSource> EnumerableTaskCompletionSources => _taskCompletionSources;
 
-    protected AbstractAsyncProcessor(IEnumerable<TInput> items, Func<TInput, Task> taskSelector, CancellationTokenSource cancellationTokenSource) : base(cancellationTokenSource)
+    private protected AbstractAsyncProcessor(IEnumerable<TInput> items, Func<TInput, Task> taskSelector, CancellationTokenSource cancellationTokenSource) : base(cancellationTokenSource)
     {
         ValidationHelper.ThrowIfNull(items);
         ValidationHelper.ThrowIfNull(taskSelector);

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableBatchProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableBatchProcessor.cs
@@ -8,6 +8,7 @@ public sealed class AsyncEnumerableBatchProcessor<TInput> : IAsyncEnumerableProc
     private readonly Func<TInput, Task> _taskSelector;
     private readonly int _batchSize;
     private readonly CancellationTokenSource _cancellationTokenSource;
+    private int _disposed;
 
     internal AsyncEnumerableBatchProcessor(
         IAsyncEnumerable<TInput> items,
@@ -48,7 +49,7 @@ public sealed class AsyncEnumerableBatchProcessor<TInput> : IAsyncEnumerableProc
         }
         finally
         {
-            _cancellationTokenSource.Dispose();
+            DisposeCancellationSource(cancelFirst: false);
         }
     }
 
@@ -60,6 +61,22 @@ public sealed class AsyncEnumerableBatchProcessor<TInput> : IAsyncEnumerableProc
 
     public void Dispose()
     {
+        DisposeCancellationSource(cancelFirst: true);
+    }
+
+    // Explicit disposal cancels in-flight work first; the completion path has nothing left to cancel.
+    private void DisposeCancellationSource(bool cancelFirst)
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        if (cancelFirst)
+        {
+            _cancellationTokenSource.Cancel();
+        }
+
         _cancellationTokenSource.Dispose();
     }
 

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableBatchProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableBatchProcessor.cs
@@ -1,8 +1,8 @@
-using EnumerableAsyncProcessor.Extensions;
+using EnumerableAsyncProcessor.Interfaces;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable;
 
-public class AsyncEnumerableBatchProcessor<TInput> : IAsyncEnumerableProcessor
+public sealed class AsyncEnumerableBatchProcessor<TInput> : IAsyncEnumerableProcessor
 {
     private readonly IAsyncEnumerable<TInput> _items;
     private readonly Func<TInput, Task> _taskSelector;
@@ -24,29 +24,48 @@ public class AsyncEnumerableBatchProcessor<TInput> : IAsyncEnumerableProcessor
     public async Task ExecuteAsync()
     {
         var cancellationToken = _cancellationTokenSource.Token;
-        var batch = new List<TInput>(_batchSize);
-        
-        await foreach (var item in _items.WithCancellation(cancellationToken).ConfigureAwait(false))
+
+        try
         {
-            batch.Add(item);
-            
-            if (batch.Count >= _batchSize)
+            var batch = new List<TInput>(_batchSize);
+
+            await foreach (var item in _items.WithCancellation(cancellationToken).ConfigureAwait(false))
             {
-                await ProcessBatch(batch, cancellationToken).ConfigureAwait(false);
-                batch = new List<TInput>(_batchSize);
+                batch.Add(item);
+
+                if (batch.Count >= _batchSize)
+                {
+                    await ProcessBatch(batch).ConfigureAwait(false);
+                    batch = new List<TInput>(_batchSize);
+                }
+            }
+
+            // Process any remaining items in the final batch
+            if (batch.Count > 0)
+            {
+                await ProcessBatch(batch).ConfigureAwait(false);
             }
         }
-        
-        // Process any remaining items in the final batch
-        if (batch.Count > 0)
+        finally
         {
-            await ProcessBatch(batch, cancellationToken).ConfigureAwait(false);
+            _cancellationTokenSource.Dispose();
         }
     }
-    
-    private async Task ProcessBatch(List<TInput> batch, CancellationToken cancellationToken)
+
+    private async Task ProcessBatch(List<TInput> batch)
     {
         var tasks = batch.Select(item => _taskSelector(item)).ToArray();
         await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Dispose();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableBatchProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableBatchProcessor.cs
@@ -9,6 +9,7 @@ public sealed class AsyncEnumerableBatchProcessor<TInput> : IAsyncEnumerableProc
     private readonly int _batchSize;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private int _disposed;
+    private Task? _executionTask;
 
     internal AsyncEnumerableBatchProcessor(
         IAsyncEnumerable<TInput> items,
@@ -22,7 +23,14 @@ public sealed class AsyncEnumerableBatchProcessor<TInput> : IAsyncEnumerableProc
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public async Task ExecuteAsync()
+    public Task ExecuteAsync()
+    {
+        var executionTask = ExecuteCoreAsync();
+        _executionTask = executionTask;
+        return executionTask;
+    }
+
+    private async Task ExecuteCoreAsync()
     {
         var cancellationToken = _cancellationTokenSource.Token;
 
@@ -80,9 +88,38 @@ public sealed class AsyncEnumerableBatchProcessor<TInput> : IAsyncEnumerableProc
         _cancellationTokenSource.Dispose();
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        Dispose();
-        return ValueTask.CompletedTask;
+        CancelForDisposal();
+
+        // Mirror ProcessorLifecycle: give the in-flight run a bounded window to observe cancellation.
+        if (_executionTask is { IsCompleted: false } executionTask)
+        {
+            try
+            {
+                await executionTask.WaitAsync(ProcessorLifecycle.DisposalTimeout).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Cancellation, failure, or timeout of the in-flight run; disposal must not throw.
+            }
+        }
+
+        DisposeCancellationSource(cancelFirst: false);
+    }
+
+    private void CancelForDisposal()
+    {
+        try
+        {
+            if (Volatile.Read(ref _disposed) == 0)
+            {
+                _cancellationTokenSource.Cancel();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // The run completed and disposed the source concurrently - nothing left to cancel.
+        }
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableOneAtATimeProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableOneAtATimeProcessor.cs
@@ -10,6 +10,7 @@ public sealed class AsyncEnumerableOneAtATimeProcessor<TInput> : IAsyncEnumerabl
     private readonly IAsyncEnumerable<TInput> _items;
     private readonly Func<TInput, Task> _taskSelector;
     private readonly CancellationTokenSource _cancellationTokenSource;
+    private int _disposed;
 
     internal AsyncEnumerableOneAtATimeProcessor(
         IAsyncEnumerable<TInput> items,
@@ -34,12 +35,28 @@ public sealed class AsyncEnumerableOneAtATimeProcessor<TInput> : IAsyncEnumerabl
         }
         finally
         {
-            _cancellationTokenSource.Dispose();
+            DisposeCancellationSource(cancelFirst: false);
         }
     }
 
     public void Dispose()
     {
+        DisposeCancellationSource(cancelFirst: true);
+    }
+
+    // Explicit disposal cancels in-flight work first; the completion path has nothing left to cancel.
+    private void DisposeCancellationSource(bool cancelFirst)
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        if (cancelFirst)
+        {
+            _cancellationTokenSource.Cancel();
+        }
+
         _cancellationTokenSource.Dispose();
     }
 

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableOneAtATimeProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableOneAtATimeProcessor.cs
@@ -1,11 +1,11 @@
-using EnumerableAsyncProcessor.Extensions;
+using EnumerableAsyncProcessor.Interfaces;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable;
 
 /// <summary>
 /// Sequential processor that processes items one at a time from an IAsyncEnumerable.
 /// </summary>
-public class AsyncEnumerableOneAtATimeProcessor<TInput> : IAsyncEnumerableProcessor
+public sealed class AsyncEnumerableOneAtATimeProcessor<TInput> : IAsyncEnumerableProcessor
 {
     private readonly IAsyncEnumerable<TInput> _items;
     private readonly Func<TInput, Task> _taskSelector;
@@ -25,9 +25,27 @@ public class AsyncEnumerableOneAtATimeProcessor<TInput> : IAsyncEnumerableProces
     {
         var cancellationToken = _cancellationTokenSource.Token;
 
-        await foreach (var item in _items.WithCancellation(cancellationToken).ConfigureAwait(false))
+        try
         {
-            await _taskSelector(item).ConfigureAwait(false);
+            await foreach (var item in _items.WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                await _taskSelector(item).ConfigureAwait(false);
+            }
         }
+        finally
+        {
+            _cancellationTokenSource.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Dispose();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableOneAtATimeProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableOneAtATimeProcessor.cs
@@ -11,6 +11,7 @@ public sealed class AsyncEnumerableOneAtATimeProcessor<TInput> : IAsyncEnumerabl
     private readonly Func<TInput, Task> _taskSelector;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private int _disposed;
+    private Task? _executionTask;
 
     internal AsyncEnumerableOneAtATimeProcessor(
         IAsyncEnumerable<TInput> items,
@@ -22,7 +23,14 @@ public sealed class AsyncEnumerableOneAtATimeProcessor<TInput> : IAsyncEnumerabl
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public async Task ExecuteAsync()
+    public Task ExecuteAsync()
+    {
+        var executionTask = ExecuteCoreAsync();
+        _executionTask = executionTask;
+        return executionTask;
+    }
+
+    private async Task ExecuteCoreAsync()
     {
         var cancellationToken = _cancellationTokenSource.Token;
 
@@ -60,9 +68,38 @@ public sealed class AsyncEnumerableOneAtATimeProcessor<TInput> : IAsyncEnumerabl
         _cancellationTokenSource.Dispose();
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        Dispose();
-        return ValueTask.CompletedTask;
+        CancelForDisposal();
+
+        // Mirror ProcessorLifecycle: give the in-flight run a bounded window to observe cancellation.
+        if (_executionTask is { IsCompleted: false } executionTask)
+        {
+            try
+            {
+                await executionTask.WaitAsync(ProcessorLifecycle.DisposalTimeout).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Cancellation, failure, or timeout of the in-flight run; disposal must not throw.
+            }
+        }
+
+        DisposeCancellationSource(cancelFirst: false);
+    }
+
+    private void CancelForDisposal()
+    {
+        try
+        {
+            if (Volatile.Read(ref _disposed) == 0)
+            {
+                _cancellationTokenSource.Cancel();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // The run completed and disposed the source concurrently - nothing left to cancel.
+        }
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableParallelProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableParallelProcessor.cs
@@ -10,6 +10,7 @@ public sealed class AsyncEnumerableParallelProcessor<TInput> : IAsyncEnumerableP
     private readonly bool _scheduleOnThreadPool;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private int _disposed;
+    private Task? _executionTask;
 
     internal AsyncEnumerableParallelProcessor(
         IAsyncEnumerable<TInput> items,
@@ -25,7 +26,14 @@ public sealed class AsyncEnumerableParallelProcessor<TInput> : IAsyncEnumerableP
         _cancellationTokenSource = cancellationTokenSource;
     }
 
-    public async Task ExecuteAsync()
+    public Task ExecuteAsync()
+    {
+        var executionTask = ExecuteCoreAsync();
+        _executionTask = executionTask;
+        return executionTask;
+    }
+
+    private async Task ExecuteCoreAsync()
     {
         var cancellationToken = _cancellationTokenSource.Token;
 
@@ -103,9 +111,38 @@ public sealed class AsyncEnumerableParallelProcessor<TInput> : IAsyncEnumerableP
         _cancellationTokenSource.Dispose();
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        Dispose();
-        return ValueTask.CompletedTask;
+        CancelForDisposal();
+
+        // Mirror ProcessorLifecycle: give the in-flight run a bounded window to observe cancellation.
+        if (_executionTask is { IsCompleted: false } executionTask)
+        {
+            try
+            {
+                await executionTask.WaitAsync(ProcessorLifecycle.DisposalTimeout).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Cancellation, failure, or timeout of the in-flight run; disposal must not throw.
+            }
+        }
+
+        DisposeCancellationSource(cancelFirst: false);
+    }
+
+    private void CancelForDisposal()
+    {
+        try
+        {
+            if (Volatile.Read(ref _disposed) == 0)
+            {
+                _cancellationTokenSource.Cancel();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // The run completed and disposed the source concurrently - nothing left to cancel.
+        }
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableParallelProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableParallelProcessor.cs
@@ -9,6 +9,7 @@ public sealed class AsyncEnumerableParallelProcessor<TInput> : IAsyncEnumerableP
     private readonly int? _maxConcurrency;
     private readonly bool _scheduleOnThreadPool;
     private readonly CancellationTokenSource _cancellationTokenSource;
+    private int _disposed;
 
     internal AsyncEnumerableParallelProcessor(
         IAsyncEnumerable<TInput> items,
@@ -77,12 +78,28 @@ public sealed class AsyncEnumerableParallelProcessor<TInput> : IAsyncEnumerableP
         }
         finally
         {
-            _cancellationTokenSource.Dispose();
+            DisposeCancellationSource(cancelFirst: false);
         }
     }
 
     public void Dispose()
     {
+        DisposeCancellationSource(cancelFirst: true);
+    }
+
+    // Explicit disposal cancels in-flight work first; the completion path has nothing left to cancel.
+    private void DisposeCancellationSource(bool cancelFirst)
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        if (cancelFirst)
+        {
+            _cancellationTokenSource.Cancel();
+        }
+
         _cancellationTokenSource.Dispose();
     }
 

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableParallelProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/AsyncEnumerableParallelProcessor.cs
@@ -1,8 +1,8 @@
-using EnumerableAsyncProcessor.Extensions;
+using EnumerableAsyncProcessor.Interfaces;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable;
 
-public class AsyncEnumerableParallelProcessor<TInput> : IAsyncEnumerableProcessor
+public sealed class AsyncEnumerableParallelProcessor<TInput> : IAsyncEnumerableProcessor
 {
     private readonly IAsyncEnumerable<TInput> _items;
     private readonly Func<TInput, Task> _taskSelector;
@@ -27,19 +27,24 @@ public class AsyncEnumerableParallelProcessor<TInput> : IAsyncEnumerableProcesso
     public async Task ExecuteAsync()
     {
         var cancellationToken = _cancellationTokenSource.Token;
-        
-        if (_maxConcurrency.HasValue)
-        {
-            await AsyncEnumerableWorkerPool.ProcessAsync(
-                _items,
-                _taskSelector,
-                _maxConcurrency.Value,
-                cancellationToken).ConfigureAwait(false);
 
-            return;
-        }
-        else
+        try
         {
+            if (_maxConcurrency.HasValue)
+            {
+                Func<TInput, Task> taskSelector = _scheduleOnThreadPool
+                    ? item => Task.Run(() => _taskSelector(item), cancellationToken)
+                    : _taskSelector;
+
+                await AsyncEnumerableWorkerPool.ProcessAsync(
+                    _items,
+                    taskSelector,
+                    _maxConcurrency.Value,
+                    cancellationToken).ConfigureAwait(false);
+
+                return;
+            }
+
             // Unbounded parallel processing
             var tasks = new List<Task>();
 
@@ -70,5 +75,20 @@ public class AsyncEnumerableParallelProcessor<TInput> : IAsyncEnumerableProcesso
                 }
             }
         }
+        finally
+        {
+            _cancellationTokenSource.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Dispose();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableBatchProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableBatchProcessor.cs
@@ -1,8 +1,9 @@
-using EnumerableAsyncProcessor.Extensions;
+using System.Runtime.CompilerServices;
+using EnumerableAsyncProcessor.Interfaces;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors;
 
-public class ResultAsyncEnumerableBatchProcessor<TInput, TOutput> : IAsyncEnumerableProcessor<TOutput>
+public sealed class ResultAsyncEnumerableBatchProcessor<TInput, TOutput> : IAsyncEnumerableProcessor<TOutput>
 {
     private readonly IAsyncEnumerable<TInput> _items;
     private readonly Func<TInput, Task<TOutput>> _taskSelector;
@@ -24,40 +25,59 @@ public class ResultAsyncEnumerableBatchProcessor<TInput, TOutput> : IAsyncEnumer
     public async IAsyncEnumerable<TOutput> ExecuteAsync()
     {
         var cancellationToken = _cancellationTokenSource.Token;
-        var batch = new List<TInput>(_batchSize);
-        
-        await foreach (var item in _items.WithCancellation(cancellationToken).ConfigureAwait(false))
+
+        try
         {
-            batch.Add(item);
-            
-            if (batch.Count >= _batchSize)
+            var batch = new List<TInput>(_batchSize);
+
+            await foreach (var item in _items.WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                batch.Add(item);
+
+                if (batch.Count >= _batchSize)
+                {
+                    await foreach (var result in ProcessBatch(batch, cancellationToken).ConfigureAwait(false))
+                    {
+                        yield return result;
+                    }
+                    batch = new List<TInput>(_batchSize);
+                }
+            }
+
+            // Process any remaining items in the final batch
+            if (batch.Count > 0)
             {
                 await foreach (var result in ProcessBatch(batch, cancellationToken).ConfigureAwait(false))
                 {
                     yield return result;
                 }
-                batch = new List<TInput>(_batchSize);
             }
         }
-        
-        // Process any remaining items in the final batch
-        if (batch.Count > 0)
+        finally
         {
-            await foreach (var result in ProcessBatch(batch, cancellationToken).ConfigureAwait(false))
-            {
-                yield return result;
-            }
+            _cancellationTokenSource.Dispose();
         }
     }
-    
-    private async IAsyncEnumerable<TOutput> ProcessBatch(List<TInput> batch, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+
+    private async IAsyncEnumerable<TOutput> ProcessBatch(List<TInput> batch, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var tasks = batch.Select(item => _taskSelector(item)).ToArray();
         var results = await Task.WhenAll(tasks).ConfigureAwait(false);
-        
+
         foreach (var result in results)
         {
             yield return result;
         }
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Dispose();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableBatchProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableBatchProcessor.cs
@@ -9,6 +9,7 @@ public sealed class ResultAsyncEnumerableBatchProcessor<TInput, TOutput> : IAsyn
     private readonly Func<TInput, Task<TOutput>> _taskSelector;
     private readonly int _batchSize;
     private readonly CancellationTokenSource _cancellationTokenSource;
+    private int _disposed;
 
     internal ResultAsyncEnumerableBatchProcessor(
         IAsyncEnumerable<TInput> items,
@@ -55,7 +56,7 @@ public sealed class ResultAsyncEnumerableBatchProcessor<TInput, TOutput> : IAsyn
         }
         finally
         {
-            _cancellationTokenSource.Dispose();
+            DisposeCancellationSource(cancelFirst: false);
         }
     }
 
@@ -72,6 +73,22 @@ public sealed class ResultAsyncEnumerableBatchProcessor<TInput, TOutput> : IAsyn
 
     public void Dispose()
     {
+        DisposeCancellationSource(cancelFirst: true);
+    }
+
+    // Explicit disposal cancels in-flight work first; the completion path has nothing left to cancel.
+    private void DisposeCancellationSource(bool cancelFirst)
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        if (cancelFirst)
+        {
+            _cancellationTokenSource.Cancel();
+        }
+
         _cancellationTokenSource.Dispose();
     }
 

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableBatchProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableBatchProcessor.cs
@@ -10,6 +10,7 @@ public sealed class ResultAsyncEnumerableBatchProcessor<TInput, TOutput> : IAsyn
     private readonly int _batchSize;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private int _disposed;
+    private TaskCompletionSource? _executionCompleted;
 
     internal ResultAsyncEnumerableBatchProcessor(
         IAsyncEnumerable<TInput> items,
@@ -25,6 +26,8 @@ public sealed class ResultAsyncEnumerableBatchProcessor<TInput, TOutput> : IAsyn
 
     public async IAsyncEnumerable<TOutput> ExecuteAsync()
     {
+        var executionCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _executionCompleted = executionCompleted;
         var cancellationToken = _cancellationTokenSource.Token;
 
         try
@@ -57,6 +60,7 @@ public sealed class ResultAsyncEnumerableBatchProcessor<TInput, TOutput> : IAsyn
         finally
         {
             DisposeCancellationSource(cancelFirst: false);
+            executionCompleted.TrySetResult();
         }
     }
 
@@ -92,9 +96,38 @@ public sealed class ResultAsyncEnumerableBatchProcessor<TInput, TOutput> : IAsyn
         _cancellationTokenSource.Dispose();
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        Dispose();
-        return ValueTask.CompletedTask;
+        CancelForDisposal();
+
+        // Mirror ProcessorLifecycle: give an in-flight enumeration a bounded window to observe cancellation.
+        if (_executionCompleted is { Task.IsCompleted: false } executionCompleted)
+        {
+            try
+            {
+                await executionCompleted.Task.WaitAsync(ProcessorLifecycle.DisposalTimeout).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Timeout of the in-flight enumeration; disposal must not throw.
+            }
+        }
+
+        DisposeCancellationSource(cancelFirst: false);
+    }
+
+    private void CancelForDisposal()
+    {
+        try
+        {
+            if (Volatile.Read(ref _disposed) == 0)
+            {
+                _cancellationTokenSource.Cancel();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // The run completed and disposed the source concurrently - nothing left to cancel.
+        }
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableOneAtATimeProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableOneAtATimeProcessor.cs
@@ -1,11 +1,11 @@
-using EnumerableAsyncProcessor.Extensions;
+using EnumerableAsyncProcessor.Interfaces;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors;
 
 /// <summary>
 /// Sequential processor that processes items one at a time and returns results in order.
 /// </summary>
-public class ResultAsyncEnumerableOneAtATimeProcessor<TInput, TOutput> : IAsyncEnumerableProcessor<TOutput>
+public sealed class ResultAsyncEnumerableOneAtATimeProcessor<TInput, TOutput> : IAsyncEnumerableProcessor<TOutput>
 {
     private readonly IAsyncEnumerable<TInput> _items;
     private readonly Func<TInput, Task<TOutput>> _taskSelector;
@@ -25,10 +25,28 @@ public class ResultAsyncEnumerableOneAtATimeProcessor<TInput, TOutput> : IAsyncE
     {
         var cancellationToken = _cancellationTokenSource.Token;
 
-        await foreach (var item in _items.WithCancellation(cancellationToken).ConfigureAwait(false))
+        try
         {
-            var result = await _taskSelector(item).ConfigureAwait(false);
-            yield return result;
+            await foreach (var item in _items.WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                var result = await _taskSelector(item).ConfigureAwait(false);
+                yield return result;
+            }
         }
+        finally
+        {
+            _cancellationTokenSource.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Dispose();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableOneAtATimeProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableOneAtATimeProcessor.cs
@@ -10,6 +10,7 @@ public sealed class ResultAsyncEnumerableOneAtATimeProcessor<TInput, TOutput> : 
     private readonly IAsyncEnumerable<TInput> _items;
     private readonly Func<TInput, Task<TOutput>> _taskSelector;
     private readonly CancellationTokenSource _cancellationTokenSource;
+    private int _disposed;
 
     internal ResultAsyncEnumerableOneAtATimeProcessor(
         IAsyncEnumerable<TInput> items,
@@ -35,12 +36,28 @@ public sealed class ResultAsyncEnumerableOneAtATimeProcessor<TInput, TOutput> : 
         }
         finally
         {
-            _cancellationTokenSource.Dispose();
+            DisposeCancellationSource(cancelFirst: false);
         }
     }
 
     public void Dispose()
     {
+        DisposeCancellationSource(cancelFirst: true);
+    }
+
+    // Explicit disposal cancels in-flight work first; the completion path has nothing left to cancel.
+    private void DisposeCancellationSource(bool cancelFirst)
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        if (cancelFirst)
+        {
+            _cancellationTokenSource.Cancel();
+        }
+
         _cancellationTokenSource.Dispose();
     }
 

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableOneAtATimeProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableOneAtATimeProcessor.cs
@@ -11,6 +11,7 @@ public sealed class ResultAsyncEnumerableOneAtATimeProcessor<TInput, TOutput> : 
     private readonly Func<TInput, Task<TOutput>> _taskSelector;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private int _disposed;
+    private TaskCompletionSource? _executionCompleted;
 
     internal ResultAsyncEnumerableOneAtATimeProcessor(
         IAsyncEnumerable<TInput> items,
@@ -24,6 +25,8 @@ public sealed class ResultAsyncEnumerableOneAtATimeProcessor<TInput, TOutput> : 
 
     public async IAsyncEnumerable<TOutput> ExecuteAsync()
     {
+        var executionCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _executionCompleted = executionCompleted;
         var cancellationToken = _cancellationTokenSource.Token;
 
         try
@@ -37,6 +40,7 @@ public sealed class ResultAsyncEnumerableOneAtATimeProcessor<TInput, TOutput> : 
         finally
         {
             DisposeCancellationSource(cancelFirst: false);
+            executionCompleted.TrySetResult();
         }
     }
 
@@ -61,9 +65,38 @@ public sealed class ResultAsyncEnumerableOneAtATimeProcessor<TInput, TOutput> : 
         _cancellationTokenSource.Dispose();
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        Dispose();
-        return ValueTask.CompletedTask;
+        CancelForDisposal();
+
+        // Mirror ProcessorLifecycle: give an in-flight enumeration a bounded window to observe cancellation.
+        if (_executionCompleted is { Task.IsCompleted: false } executionCompleted)
+        {
+            try
+            {
+                await executionCompleted.Task.WaitAsync(ProcessorLifecycle.DisposalTimeout).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Timeout of the in-flight enumeration; disposal must not throw.
+            }
+        }
+
+        DisposeCancellationSource(cancelFirst: false);
+    }
+
+    private void CancelForDisposal()
+    {
+        try
+        {
+            if (Volatile.Read(ref _disposed) == 0)
+            {
+                _cancellationTokenSource.Cancel();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // The run completed and disposed the source concurrently - nothing left to cancel.
+        }
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableParallelProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableParallelProcessor.cs
@@ -1,8 +1,9 @@
 using EnumerableAsyncProcessor.Extensions;
+using EnumerableAsyncProcessor.Interfaces;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors.AsyncEnumerable.ResultProcessors;
 
-public class ResultAsyncEnumerableParallelProcessor<TInput, TOutput> : IAsyncEnumerableProcessor<TOutput>
+public sealed class ResultAsyncEnumerableParallelProcessor<TInput, TOutput> : IAsyncEnumerableProcessor<TOutput>
 {
     private readonly IAsyncEnumerable<TInput> _items;
     private readonly Func<TInput, Task<TOutput>> _taskSelector;
@@ -27,61 +28,84 @@ public class ResultAsyncEnumerableParallelProcessor<TInput, TOutput> : IAsyncEnu
     public async IAsyncEnumerable<TOutput> ExecuteAsync()
     {
         var cancellationToken = _cancellationTokenSource.Token;
-        if (_maxConcurrency.HasValue)
-        {
-            await foreach (var result in AsyncEnumerableWorkerPool.ProcessResultsAsync(
-                               _items,
-                               _taskSelector,
-                               _maxConcurrency.Value,
-                               cancellationToken).ConfigureAwait(false))
-            {
-                yield return result;
-            }
 
-            yield break;
-        }
-
-        var tasks = new List<Task<TOutput>>();
-
-        // Unbounded parallel processing
         try
         {
-            await foreach (var item in _items.WithCancellation(cancellationToken).ConfigureAwait(false))
+            if (_maxConcurrency.HasValue)
             {
-                var capturedItem = item;
+                Func<TInput, Task<TOutput>> taskSelector = _scheduleOnThreadPool
+                    ? item => Task.Run(() => _taskSelector(item), cancellationToken)
+                    : _taskSelector;
 
-                Task<TOutput> task;
-                if (_scheduleOnThreadPool)
+                await foreach (var result in AsyncEnumerableWorkerPool.ProcessResultsAsync(
+                                   _items,
+                                   taskSelector,
+                                   _maxConcurrency.Value,
+                                   cancellationToken).ConfigureAwait(false))
                 {
-                    task = Task.Run(() => _taskSelector(capturedItem), cancellationToken);
-                }
-                else
-                {
-                    task = _taskSelector(capturedItem);
+                    yield return result;
                 }
 
-                tasks.Add(task);
+                yield break;
             }
 
-            // Yield all results as they complete
-            await foreach (var result in tasks.ToIAsyncEnumerable(cancellationToken).ConfigureAwait(false))
+            var tasks = new List<Task<TOutput>>();
+
+            // Unbounded parallel processing
+            try
             {
-                yield return result;
+                await foreach (var item in _items.WithCancellation(cancellationToken).ConfigureAwait(false))
+                {
+                    var capturedItem = item;
+
+                    Task<TOutput> task;
+                    if (_scheduleOnThreadPool)
+                    {
+                        task = Task.Run(() => _taskSelector(capturedItem), cancellationToken);
+                    }
+                    else
+                    {
+                        task = _taskSelector(capturedItem);
+                    }
+
+                    tasks.Add(task);
+                }
+
+                // Yield all results as they complete
+                await foreach (var result in tasks.ToIAsyncEnumerable(cancellationToken).ConfigureAwait(false))
+                {
+                    yield return result;
+                }
+            }
+            finally
+            {
+                if (tasks.Count > 0)
+                {
+                    try
+                    {
+                        await Task.WhenAll(tasks).ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // Preserve the exception already propagating from enumeration or result consumption.
+                    }
+                }
             }
         }
         finally
         {
-            if (tasks.Count > 0)
-            {
-                try
-                {
-                    await Task.WhenAll(tasks).ConfigureAwait(false);
-                }
-                catch
-                {
-                    // Preserve the exception already propagating from enumeration or result consumption.
-                }
-            }
+            _cancellationTokenSource.Dispose();
         }
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Dispose();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableParallelProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableParallelProcessor.cs
@@ -10,6 +10,7 @@ public sealed class ResultAsyncEnumerableParallelProcessor<TInput, TOutput> : IA
     private readonly int? _maxConcurrency;
     private readonly bool _scheduleOnThreadPool;
     private readonly CancellationTokenSource _cancellationTokenSource;
+    private int _disposed;
 
     internal ResultAsyncEnumerableParallelProcessor(
         IAsyncEnumerable<TInput> items,
@@ -94,12 +95,28 @@ public sealed class ResultAsyncEnumerableParallelProcessor<TInput, TOutput> : IA
         }
         finally
         {
-            _cancellationTokenSource.Dispose();
+            DisposeCancellationSource(cancelFirst: false);
         }
     }
 
     public void Dispose()
     {
+        DisposeCancellationSource(cancelFirst: true);
+    }
+
+    // Explicit disposal cancels in-flight work first; the completion path has nothing left to cancel.
+    private void DisposeCancellationSource(bool cancelFirst)
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        if (cancelFirst)
+        {
+            _cancellationTokenSource.Cancel();
+        }
+
         _cancellationTokenSource.Dispose();
     }
 

--- a/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableParallelProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/AsyncEnumerable/ResultProcessors/ResultAsyncEnumerableParallelProcessor.cs
@@ -11,6 +11,7 @@ public sealed class ResultAsyncEnumerableParallelProcessor<TInput, TOutput> : IA
     private readonly bool _scheduleOnThreadPool;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private int _disposed;
+    private TaskCompletionSource? _executionCompleted;
 
     internal ResultAsyncEnumerableParallelProcessor(
         IAsyncEnumerable<TInput> items,
@@ -28,6 +29,8 @@ public sealed class ResultAsyncEnumerableParallelProcessor<TInput, TOutput> : IA
 
     public async IAsyncEnumerable<TOutput> ExecuteAsync()
     {
+        var executionCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _executionCompleted = executionCompleted;
         var cancellationToken = _cancellationTokenSource.Token;
 
         try
@@ -96,6 +99,7 @@ public sealed class ResultAsyncEnumerableParallelProcessor<TInput, TOutput> : IA
         finally
         {
             DisposeCancellationSource(cancelFirst: false);
+            executionCompleted.TrySetResult();
         }
     }
 
@@ -120,9 +124,38 @@ public sealed class ResultAsyncEnumerableParallelProcessor<TInput, TOutput> : IA
         _cancellationTokenSource.Dispose();
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        Dispose();
-        return ValueTask.CompletedTask;
+        CancelForDisposal();
+
+        // Mirror ProcessorLifecycle: give an in-flight enumeration a bounded window to observe cancellation.
+        if (_executionCompleted is { Task.IsCompleted: false } executionCompleted)
+        {
+            try
+            {
+                await executionCompleted.Task.WaitAsync(ProcessorLifecycle.DisposalTimeout).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Timeout of the in-flight enumeration; disposal must not throw.
+            }
+        }
+
+        DisposeCancellationSource(cancelFirst: false);
+    }
+
+    private void CancelForDisposal()
+    {
+        try
+        {
+            if (Volatile.Read(ref _disposed) == 0)
+            {
+                _cancellationTokenSource.Cancel();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // The run completed and disposed the source concurrently - nothing left to cancel.
+        }
     }
 }

--- a/EnumerableAsyncProcessor/RunnableProcessors/BatchAsyncProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/BatchAsyncProcessor.cs
@@ -3,7 +3,7 @@ using EnumerableAsyncProcessor.Validation;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors;
 
-public class BatchAsyncProcessor : AbstractAsyncProcessor
+public sealed class BatchAsyncProcessor : AbstractAsyncProcessor
 {
     private readonly int _batchSize;
 

--- a/EnumerableAsyncProcessor/RunnableProcessors/BatchAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/BatchAsyncProcessor_1.cs
@@ -3,7 +3,7 @@ using EnumerableAsyncProcessor.Validation;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors;
 
-public class BatchAsyncProcessor<TInput> : AbstractAsyncProcessor<TInput>
+public sealed class BatchAsyncProcessor<TInput> : AbstractAsyncProcessor<TInput>
 {
     private readonly int _batchSize;
 

--- a/EnumerableAsyncProcessor/RunnableProcessors/OneAtATimeAsyncProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/OneAtATimeAsyncProcessor.cs
@@ -2,7 +2,7 @@ using EnumerableAsyncProcessor.RunnableProcessors.Abstract;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors;
 
-public class OneAtATimeAsyncProcessor : AbstractAsyncProcessor
+public sealed class OneAtATimeAsyncProcessor : AbstractAsyncProcessor
 {
     internal OneAtATimeAsyncProcessor(int count, Func<Task> taskSelector, CancellationTokenSource cancellationTokenSource) : base(count, taskSelector, cancellationTokenSource)
     {

--- a/EnumerableAsyncProcessor/RunnableProcessors/OneAtATimeAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/OneAtATimeAsyncProcessor_1.cs
@@ -2,7 +2,7 @@ using EnumerableAsyncProcessor.RunnableProcessors.Abstract;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors;
 
-public class OneAtATimeAsyncProcessor<TInput> : AbstractAsyncProcessor<TInput>
+public sealed class OneAtATimeAsyncProcessor<TInput> : AbstractAsyncProcessor<TInput>
 {
     internal OneAtATimeAsyncProcessor(IEnumerable<TInput> items, Func<TInput, Task> taskSelector, CancellationTokenSource cancellationTokenSource) : base(items, taskSelector, cancellationTokenSource)
     {

--- a/EnumerableAsyncProcessor/RunnableProcessors/ParallelAsyncProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ParallelAsyncProcessor.cs
@@ -3,7 +3,7 @@ using EnumerableAsyncProcessor.Validation;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors;
 
-public class ParallelAsyncProcessor : AbstractAsyncProcessor
+public sealed class ParallelAsyncProcessor : AbstractAsyncProcessor
 {
     private readonly int? _maxConcurrency;
     private readonly bool _scheduleOnThreadPool;

--- a/EnumerableAsyncProcessor/RunnableProcessors/ParallelAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ParallelAsyncProcessor_1.cs
@@ -3,7 +3,7 @@ using EnumerableAsyncProcessor.Validation;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors;
 
-public class ParallelAsyncProcessor<TInput> : AbstractAsyncProcessor<TInput>
+public sealed class ParallelAsyncProcessor<TInput> : AbstractAsyncProcessor<TInput>
 {
     private readonly int? _maxConcurrency;
     private readonly bool _scheduleOnThreadPool;

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/Abstract/ResultAbstractAsyncProcessorBase.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/Abstract/ResultAbstractAsyncProcessorBase.cs
@@ -6,15 +6,15 @@ namespace EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract;
 
 public abstract class ResultAbstractAsyncProcessorBase<TOutput> : IAsyncProcessor<TOutput>, IAsyncDisposable, IDisposable
 {
-    protected abstract IReadOnlyList<TaskCompletionSource<TOutput>> EnumerableTaskCompletionSources { get; }
-    protected readonly CancellationToken CancellationToken;
+    private protected abstract IReadOnlyList<TaskCompletionSource<TOutput>> EnumerableTaskCompletionSources { get; }
+    private protected readonly CancellationToken CancellationToken;
 
     private readonly ProcessorLifecycle _lifecycle;
     private Task<TOutput[]>? _results;
 
     private Task<TOutput[]> Results => _results ??= Task.WhenAll(GetEnumerableTasks());
 
-    protected ResultAbstractAsyncProcessorBase(CancellationTokenSource cancellationTokenSource)
+    private protected ResultAbstractAsyncProcessorBase(CancellationTokenSource cancellationTokenSource)
     {
         _lifecycle = new ProcessorLifecycle(cancellationTokenSource, TrySetCanceledAll, TrySetExceptionAll);
         CancellationToken = _lifecycle.Token;
@@ -75,7 +75,7 @@ public abstract class ResultAbstractAsyncProcessorBase<TOutput> : IAsyncProcesso
         GC.SuppressFinalize(this);
     }
 
-    protected virtual ValueTask DisposeAsyncCore()
+    private protected virtual ValueTask DisposeAsyncCore()
     {
         return ValueTask.CompletedTask;
     }

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/Abstract/ResultAbstractAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/Abstract/ResultAbstractAsyncProcessor_1.cs
@@ -4,13 +4,13 @@ namespace EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract;
 
 public abstract class ResultAbstractAsyncProcessor<TOutput> : ResultAbstractAsyncProcessorBase<TOutput>
 {
-    protected readonly ActionTaskWrapper<TOutput>[] TaskWrappers;
+    private protected readonly ActionTaskWrapper<TOutput>[] TaskWrappers;
 
     private readonly TaskCompletionSource<TOutput>[] _taskCompletionSources;
 
-    protected override IReadOnlyList<TaskCompletionSource<TOutput>> EnumerableTaskCompletionSources => _taskCompletionSources;
+    private protected override IReadOnlyList<TaskCompletionSource<TOutput>> EnumerableTaskCompletionSources => _taskCompletionSources;
 
-    protected ResultAbstractAsyncProcessor(int count, Func<Task<TOutput>> taskSelector, CancellationTokenSource cancellationTokenSource) : base(cancellationTokenSource)
+    private protected ResultAbstractAsyncProcessor(int count, Func<Task<TOutput>> taskSelector, CancellationTokenSource cancellationTokenSource) : base(cancellationTokenSource)
     {
         ValidationHelper.ThrowIfNegative(count);
         ValidationHelper.ThrowIfNull(taskSelector);

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/Abstract/ResultAbstractAsyncProcessor_2.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/Abstract/ResultAbstractAsyncProcessor_2.cs
@@ -4,13 +4,13 @@ namespace EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract;
 
 public abstract class ResultAbstractAsyncProcessor<TInput, TOutput> : ResultAbstractAsyncProcessorBase<TOutput>
 {
-    protected readonly ItemTaskWrapper<TInput, TOutput>[] TaskWrappers;
+    private protected readonly ItemTaskWrapper<TInput, TOutput>[] TaskWrappers;
 
     private readonly TaskCompletionSource<TOutput>[] _taskCompletionSources;
 
-    protected override IReadOnlyList<TaskCompletionSource<TOutput>> EnumerableTaskCompletionSources => _taskCompletionSources;
+    private protected override IReadOnlyList<TaskCompletionSource<TOutput>> EnumerableTaskCompletionSources => _taskCompletionSources;
 
-    protected ResultAbstractAsyncProcessor(IEnumerable<TInput> items, Func<TInput, Task<TOutput>> taskSelector, CancellationTokenSource cancellationTokenSource) : base(cancellationTokenSource)
+    private protected ResultAbstractAsyncProcessor(IEnumerable<TInput> items, Func<TInput, Task<TOutput>> taskSelector, CancellationTokenSource cancellationTokenSource) : base(cancellationTokenSource)
     {
         ValidationHelper.ThrowIfNull(items);
         ValidationHelper.ThrowIfNull(taskSelector);

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultBatchAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultBatchAsyncProcessor_1.cs
@@ -3,7 +3,7 @@ using EnumerableAsyncProcessor.Validation;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors;
 
-public class ResultBatchAsyncProcessor<TOutput> : ResultAbstractAsyncProcessor<TOutput>
+public sealed class ResultBatchAsyncProcessor<TOutput> : ResultAbstractAsyncProcessor<TOutput>
 {
     private readonly int _batchSize;
 

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultBatchAsyncProcessor_2.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultBatchAsyncProcessor_2.cs
@@ -3,7 +3,7 @@ using EnumerableAsyncProcessor.Validation;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors;
 
-public class ResultBatchAsyncProcessor<TInput, TOutput> : ResultAbstractAsyncProcessor<TInput, TOutput>
+public sealed class ResultBatchAsyncProcessor<TInput, TOutput> : ResultAbstractAsyncProcessor<TInput, TOutput>
 {
     private readonly int _batchSize;
 

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultOneAtATimeAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultOneAtATimeAsyncProcessor_1.cs
@@ -2,7 +2,7 @@ using EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors;
 
-public class ResultOneAtATimeAsyncProcessor<TOutput> : ResultAbstractAsyncProcessor<TOutput>
+public sealed class ResultOneAtATimeAsyncProcessor<TOutput> : ResultAbstractAsyncProcessor<TOutput>
 {
     internal ResultOneAtATimeAsyncProcessor(int count, Func<Task<TOutput>> taskSelector, CancellationTokenSource cancellationTokenSource) : base(count, taskSelector, cancellationTokenSource)
     {

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultOneAtATimeAsyncProcessor_2.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultOneAtATimeAsyncProcessor_2.cs
@@ -2,7 +2,7 @@ using EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors.Abstract;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors;
 
-public class ResultOneAtATimeAsyncProcessor<TInput, TOutput> : ResultAbstractAsyncProcessor<TInput, TOutput>
+public sealed class ResultOneAtATimeAsyncProcessor<TInput, TOutput> : ResultAbstractAsyncProcessor<TInput, TOutput>
 {
     internal ResultOneAtATimeAsyncProcessor(IEnumerable<TInput> items, Func<TInput, Task<TOutput>> taskSelector, CancellationTokenSource cancellationTokenSource) : base(items, taskSelector, cancellationTokenSource)
     {

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultParallelAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultParallelAsyncProcessor_1.cs
@@ -3,7 +3,7 @@ using EnumerableAsyncProcessor.Validation;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors;
 
-public class ResultParallelAsyncProcessor<TOutput> : ResultAbstractAsyncProcessor<TOutput>
+public sealed class ResultParallelAsyncProcessor<TOutput> : ResultAbstractAsyncProcessor<TOutput>
 {
     private readonly int? _maxConcurrency;
     private readonly bool _scheduleOnThreadPool;

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultParallelAsyncProcessor_2.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultParallelAsyncProcessor_2.cs
@@ -3,7 +3,7 @@ using EnumerableAsyncProcessor.Validation;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors;
 
-public class ResultParallelAsyncProcessor<TInput, TOutput> : ResultAbstractAsyncProcessor<TInput, TOutput>
+public sealed class ResultParallelAsyncProcessor<TInput, TOutput> : ResultAbstractAsyncProcessor<TInput, TOutput>
 {
     private readonly int? _maxConcurrency;
     private readonly bool _scheduleOnThreadPool;

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultTimedRateLimitedParallelAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultTimedRateLimitedParallelAsyncProcessor_1.cs
@@ -3,7 +3,7 @@ using EnumerableAsyncProcessor.Validation;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors;
 
-public class ResultTimedRateLimitedParallelAsyncProcessor<TOutput> : ResultAbstractAsyncProcessor<TOutput>
+public sealed class ResultTimedRateLimitedParallelAsyncProcessor<TOutput> : ResultAbstractAsyncProcessor<TOutput>
 {
     private readonly int _permitsPerWindow;
     private readonly TimeSpan _window;

--- a/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultTimedRateLimitedParallelAsyncProcessor_2.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/ResultProcessors/ResultTimedRateLimitedParallelAsyncProcessor_2.cs
@@ -3,7 +3,7 @@ using EnumerableAsyncProcessor.Validation;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors.ResultProcessors;
 
-public class ResultTimedRateLimitedParallelAsyncProcessor<TInput, TOutput> : ResultAbstractAsyncProcessor<TInput, TOutput>
+public sealed class ResultTimedRateLimitedParallelAsyncProcessor<TInput, TOutput> : ResultAbstractAsyncProcessor<TInput, TOutput>
 {
     private readonly int _permitsPerWindow;
     private readonly TimeSpan _window;

--- a/EnumerableAsyncProcessor/RunnableProcessors/TimedRateLimitedParallelAsyncProcessor.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/TimedRateLimitedParallelAsyncProcessor.cs
@@ -3,7 +3,7 @@ using EnumerableAsyncProcessor.Validation;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors;
 
-public class TimedRateLimitedParallelAsyncProcessor : AbstractAsyncProcessor
+public sealed class TimedRateLimitedParallelAsyncProcessor : AbstractAsyncProcessor
 {
     private readonly int _permitsPerWindow;
     private readonly TimeSpan _window;

--- a/EnumerableAsyncProcessor/RunnableProcessors/TimedRateLimitedParallelAsyncProcessor_1.cs
+++ b/EnumerableAsyncProcessor/RunnableProcessors/TimedRateLimitedParallelAsyncProcessor_1.cs
@@ -3,7 +3,7 @@ using EnumerableAsyncProcessor.Validation;
 
 namespace EnumerableAsyncProcessor.RunnableProcessors;
 
-public class TimedRateLimitedParallelAsyncProcessor<TInput> : AbstractAsyncProcessor<TInput>
+public sealed class TimedRateLimitedParallelAsyncProcessor<TInput> : AbstractAsyncProcessor<TInput>
 {
     private readonly int _permitsPerWindow;
     private readonly TimeSpan _window;

--- a/EnumerableAsyncProcessor/TaskWrapper.cs
+++ b/EnumerableAsyncProcessor/TaskWrapper.cs
@@ -53,7 +53,7 @@ internal static class TaskCompletionSourceExtensions
 /// <summary>
 /// A struct wrapper pairing an action task factory with its completion source.
 /// </summary>
-public readonly struct ActionTaskWrapper : ITaskWrapper
+internal readonly struct ActionTaskWrapper : ITaskWrapper
 {
     public readonly Func<Task> TaskFactory;
     public readonly TaskCompletionSource TaskCompletionSource;
@@ -89,7 +89,7 @@ public readonly struct ActionTaskWrapper : ITaskWrapper
 /// <summary>
 /// A struct wrapper pairing an input item and its task factory with a completion source.
 /// </summary>
-public readonly struct ItemTaskWrapper<TInput> : ITaskWrapper
+internal readonly struct ItemTaskWrapper<TInput> : ITaskWrapper
 {
     public readonly TInput Input;
     public readonly Func<TInput, Task> TaskFactory;
@@ -127,7 +127,7 @@ public readonly struct ItemTaskWrapper<TInput> : ITaskWrapper
 /// <summary>
 /// A struct wrapper pairing an input item and its result-producing task factory with a completion source.
 /// </summary>
-public readonly struct ItemTaskWrapper<TInput, TOutput> : ITaskWrapper
+internal readonly struct ItemTaskWrapper<TInput, TOutput> : ITaskWrapper
 {
     public readonly TInput Input;
     public readonly Func<TInput, Task<TOutput>> TaskFactory;
@@ -164,7 +164,7 @@ public readonly struct ItemTaskWrapper<TInput, TOutput> : ITaskWrapper
 /// <summary>
 /// A struct wrapper pairing a result-producing task factory with its completion source.
 /// </summary>
-public readonly struct ActionTaskWrapper<TOutput> : ITaskWrapper
+internal readonly struct ActionTaskWrapper<TOutput> : ITaskWrapper
 {
     public readonly Func<Task<TOutput>> TaskFactory;
     public readonly TaskCompletionSource<TOutput> TaskCompletionSource;

--- a/README.md
+++ b/README.md
@@ -25,13 +25,16 @@ Version 4 requires .NET 8 or later. The package targets and tests `net8.0`, `net
 Version 4 is a major release. Review these source and behaviour changes before upgrading:
 
 - **.NET 8 is the minimum runtime.** The `net6.0` and `netstandard2.0` targets, the Polyfill dependency, and the `TaskCompletionSource` compatibility shim were removed. The package targets and tests `net8.0`, `net9.0`, and `net10.0`.
-- **Parallel processing has one API.** Use `ProcessInParallel(maxConcurrency: 100)` for bounded concurrency and `ProcessInParallel()` for unbounded concurrency. The old non-timed `RateLimitedParallelAsyncProcessor*` types and duplicate overload family were removed. Rename named `levelOfParallelism` arguments to `maxConcurrency`; replace positional `ProcessInParallel(true)` calls with `ProcessInParallel(scheduleOnThreadPool: true)`.
+- **Parallel processing has one API.** Use `ProcessInParallel(maxConcurrency: 100)` for bounded concurrency and `ProcessInParallel()` for unbounded concurrency. The old non-timed `RateLimitedParallelAsyncProcessor*` types and duplicate overload family were removed. Rename named `levelOfParallelism` arguments to `maxConcurrency` on the `ProcessInParallel` builder family (`InParallelAsync` keeps its `levelOfParallelism` parameter name); replace positional `ProcessInParallel(true)` calls with `ProcessInParallel(scheduleOnThreadPool: true)`.
+- **The parameterized no-selector `IAsyncEnumerable<T>.ProcessInParallel(maxConcurrency, ...)` overloads were removed.** They only buffered the stream into a list — their `maxConcurrency`/`scheduleOnThreadPool` parameters had no effect. Pass a selector (`items.ProcessInParallel(item => Task.FromResult(item), maxConcurrency)`) instead. The parameterless `ProcessInParallel(cancellationToken)` overload remains for binary compatibility with v3-compiled assemblies (notably TUnit) and is documented as a plain collect.
+- **`IAsyncEnumerableProcessor` moved to `EnumerableAsyncProcessor.Interfaces`** (previously `EnumerableAsyncProcessor.Extensions`) and now implements `IAsyncDisposable`/`IDisposable`. Processors returned by the `IAsyncEnumerable<T>` builder path dispose their internal resources automatically when `ExecuteAsync` completes; they are single-use.
+- **Processor and builder classes are sealed.** None of them were externally subclassable in practice (their pipelines hinge on internal members); v4 makes that explicit.
 - **Timed processing is a real start-rate limit.** It now uses a shared token bucket instead of holding each worker slot for at least one window. `ProcessInParallel(permitsPerWindow, window, maxConcurrency)` controls start rate and in-flight concurrency independently. The existing two-argument overload remains and uses its first value for both limits.
 - **`IEnumerable<T>` input is materialized once when the processor is built.** One-shot enumerables are now supported and side effects run once. Iterator exceptions surface from the terminal builder call, such as `ProcessInParallel(...)`, instead of later from an awaiter.
 - **Synchronous disposal no longer waits.** `Dispose()` cancels pending work and releases resources without blocking. Use `await DisposeAsync()` or `await using` when shutdown must wait for in-flight work; the async wait is bounded to 30 seconds.
 - **Arbitrary upper limits were removed.** Task counts and batch sizes may exceed 10,000, and time windows may exceed 24 hours. Validity checks remain: counts, batch sizes, concurrency, and permit counts must be positive; time windows cannot be negative.
 - **Validation is consistent and eager.** Invalid `maxConcurrency`, parallelism, batch, and timed-rate arguments now throw while the processor is built for both action and result variants.
-- **Incidental `TaskWrapper` API was removed.** `IEquatable<T>`, equality operators, `Deconstruct`, and custom `GetHashCode` members were implementation details and are no longer public. Recompile consumers that referenced those members.
+- **`TaskWrapper` types and processor plumbing are internal.** The `ActionTaskWrapper`/`ItemTaskWrapper` structs and the previously `protected` members of the abstract processor base classes (`TaskWrappers`, `EnumerableTaskCompletionSources`, `CancellationToken`, constructors) were implementation details that could not be meaningfully used outside the library, and are no longer public.
 - **Synchronous `InParallelAsync` delegates now run concurrently.** The `Func<TSource, TResult>` and `Action<TSource>` overloads use thread-pool workers instead of executing delegates sequentially on the caller. Do not depend on their previous thread affinity or execution order.
 
 Version 4 also adds cancellation-aware selectors. Use `(item, cancellationToken) => ...` when in-flight work must observe external cancellation, `CancelAll()`, or disposal:
@@ -391,13 +394,14 @@ When a processor is disposed:
 
 ### Extension Method Disposal
 
-Note that the convenience extension methods like `IAsyncEnumerable<T>.ProcessInParallel()` handle disposal automatically and return the final results directly:
+Note that the convenience extension methods like `IAsyncEnumerable<T>.ProcessInParallel(selector)` handle disposal automatically and return the final results directly:
 
 ```csharp
 // These extension methods handle disposal internally
-var results = await asyncEnumerable.ProcessInParallel();
 var transformedResults = await asyncEnumerable.ProcessInParallel(async x => await TransformAsync(x));
 ```
+
+Processors built from an `IAsyncEnumerable<T>` source (`IAsyncEnumerableProcessor`) also dispose their internal resources automatically when `ExecuteAsync` completes; `await using` is still supported and safe if `ExecuteAsync` is never called.
 
 The disposal guidance above applies when you're working with the processor objects directly (using the builder pattern).
 


### PR DESCRIPTION
Now-or-never API cleanup before 4.0.0 freezes the contract, from the pre-release audit.

## API surface (breaking)

- **TaskWrapper structs internalized** (`ActionTaskWrapper`, `ItemTaskWrapper` × arities). Both base hierarchies declare `internal abstract Task Process()`, so no external subclass was ever possible — every `protected` member on the abstract bases was unreachable noise about to be frozen. Those members (`TaskWrappers`, `EnumerableTaskCompletionSources`, `CancellationToken`, constructors, `DisposeAsyncCore`) are now `private protected`. Tests keep access via `InternalsVisibleTo`.
- **All ~24 leaf processor and builder classes are `sealed`** — zero-risk today (internal ctors/members already prevented subclassing), binary-breaking to do later.
- **`IAsyncEnumerableProcessor` moved to `EnumerableAsyncProcessor.Interfaces`** (was declared in the `Extensions` namespace despite living in `Interfaces/`) and both variants now extend `IAsyncDisposable, IDisposable`. `IAsyncEnumerableProcessor<TOutput>` is also covariant now.
- **Parameterized no-selector `IAsyncEnumerable<T>.ProcessInParallel(maxConcurrency, …)` overloads removed** — they buffered the stream into a list and silently ignored `maxConcurrency`/`scheduleOnThreadPool`.

## Behavior fixes

- **Linked `CancellationTokenSource` leak fixed**: the async-enumerable builder path created a linked CTS nobody ever disposed, pinning a registration on the caller's token for its lifetime. The six async-enumerable processors now dispose it when `ExecuteAsync` completes and support explicit `Dispose`/`DisposeAsync` (idempotent; `await using` without execution is safe).
- **`scheduleOnThreadPool` is honored on bounded paths** — previously ignored whenever `maxConcurrency` was set (both processors and the extension overload).

## TUnit binary compatibility (important)

`TUnit.Engine` is compiled against EnumerableAsyncProcessor **3.8.4**, and any locally-referenced v4 build shadows it (same assembly identity). Two members TUnit binds to had been removed: `ItemActionAsyncProcessorBuilder<,>.ProcessInParallel(int)` (removed in the v4 consolidation — this had already silently broken `--treenode-filter` discovery on main) and the parameterless `ProcessInParallel<T>(IAsyncEnumerable<T>, CancellationToken)`. Without them, TUnit test discovery dies with `MissingMethodException` — in this repo and for any TUnit user who adds EAP 4.0 to a test project.

This PR keeps **two functional, documented, transitional compat members**: `ProcessInParallel(int)` forwarders on the four enumerable builders, and the parameterless collect overload (docs state plainly that it parallelizes nothing). `V3BinaryCompatibilityTests` pins the exact signatures with an explanation. They can be dropped once TUnit ships a build compiled against v4 — or better, internalizes EAP into `TUnit.Engine` (ILRepack), which ends the diamond dependency permanently. Side effect: `--treenode-filter` works again for the first time since the consolidation.

## Packaging

- `GenerateDocumentationFile` — the package previously shipped **no IntelliSense XML** despite extensive `///` docs.
- `IsAotCompatible` (library uses zero reflection).
- Merged duplicate metadata `PropertyGroup`s; removed dead private `ToAsyncEnumerable` helper.
- `PublicAPI.Shipped.txt` regenerated (176→181 entries reflecting all of the above).

## Docs

- Migration guide: new bullets for the namespace move, sealing, wrapper internalization, no-selector removal; corrected the `levelOfParallelism` rename claim (`InParallelAsync` keeps that parameter name).
- README: disposal claims now accurate for the async-enumerable family.
- CLAUDE.md: removed stale `RateLimitedParallel` strategy and `minimumIterationTime` slot-dwell description (now token bucket); documented the TUnit dogfooding constraint.

## Tests

1659 passing across net8.0/net9.0/net10.0 (removed 2 tests for deleted overloads; added 2 async-enumerable disposal regression tests + the TUnit compat guard). Filtered discovery verified working.